### PR TITLE
RFR: Add tests for local-shell-script runner

### DIFF
--- a/packs/fixtures/actions/streamwriter-script-local.yaml
+++ b/packs/fixtures/actions/streamwriter-script-local.yaml
@@ -1,0 +1,24 @@
+---
+description: Simple script action to test output to different streams.
+enabled: true
+entry_point: scripts/streamwriter-script.py
+name: streamwriter-script-local
+parameters:
+  stream:
+    type: string
+    description: Stream to write to (stdout or stderr).
+    required: true
+  str_arg:
+    type: string
+    description: Some string arg.
+  int_arg:
+    type: number
+    description: Some int arg.
+  obj_arg:
+    type: object
+    description: Some object arg.
+  sudo:
+    immutable: true
+  kwarg_op:
+    immutable: true
+runner_type: "local-shell-script"

--- a/packs/tests/actions/chains/test_quickstart_local_script_actions.yaml
+++ b/packs/tests/actions/chains/test_quickstart_local_script_actions.yaml
@@ -1,0 +1,63 @@
+---
+chain:
+  -
+    name: "test_stdout_local_script_action"
+    ref: "fixtures.streamwriter-script-local"
+    params:
+        stream: "stdout"
+        str_arg: "foo"
+        int_arg: 1
+        obj_arg:
+            foo: bar
+    on-success: "assert_stdout_field_stdout_test"
+  -
+    name: "assert_stdout_field_stdout_test"
+    ref: "asserts.object_key_string_equals"
+    params:
+        object: "{{test_stdout_local_script_action}}"
+        key: "stdout"
+        value: "STREAM IS STDOUT. STR: foo INT: 1 OBJ: {u'foo': u'bar'}"
+    on-success: "assert_return_code_zero_stdout_test"
+  -
+    name: "assert_return_code_zero_stdout_test"
+    ref: "asserts.object_key_number_equals"
+    params:
+        object: "{{test_stdout_local_script_action}}"
+        key: "return_code"
+        value: 0
+    on-success: "test_stderr_local_script_action"
+  -
+    name: "test_stderr_local_script_action"
+    ref: "fixtures.streamwriter-script-local"
+    params:
+        stream: "stderr"
+    on-success: "assert_stderr_field_stderr_test"
+  -
+    name: "assert_stderr_field_stderr_test"
+    ref: "asserts.object_key_string_equals"
+    params:
+        object: "{{test_stderr_local_script_action}}"
+        key: "stderr"
+        value: "STREAM IS STDERR."
+    on-success: "assert_return_code_zero_stderr_test"
+  -
+    name: "assert_return_code_zero_stderr_test"
+    ref: "asserts.object_key_number_equals"
+    params:
+        object: "{{test_stderr_local_script_action}}"
+        key: "return_code"
+        value: 0
+    on-success: "test_exception_local_script_action"
+  -
+    name: "test_exception_local_script_action"
+    ref: "fixtures.streamwriter-script-local"
+    params:
+        stream: "shyte"
+    on-failure: "assert_return_code_non_zero_exception_test"
+  -
+    name: "assert_return_code_non_zero_exception_test"
+    ref: "asserts.object_key_number_greater"
+    params:
+        object: "{{test_exception_local_script_action}}"
+        key: "return_code"
+        value: 0

--- a/packs/tests/actions/test_quickstart_local_script_actions.yaml
+++ b/packs/tests/actions/test_quickstart_local_script_actions.yaml
@@ -1,0 +1,12 @@
+---
+# Action definition metadata
+name: "test_quickstart_local_script_actions"
+description: "Workflow tests local script action on Quick Start"
+runner_type: "action-chain"
+enabled: true
+entry_point: "chains/test_quickstart_local_script_actions.yaml"
+parameters:
+  token:
+    type: "string"
+    description: "st2 auth token"
+    default: ""


### PR DESCRIPTION
Some copy paste and rename variables gets us a test. Why not? 

```
(virtualenv)/m/s/s/st2 git:master ❯❯❯ st2 run tests.test_quickstart_local_script_actions                                                                                                                                                                   ✭
.....
id: 556cdb7932ed350e97765435
action.ref: tests.test_quickstart_local_script_actions
status: succeeded
start_timestamp: 2015-06-01T23:23:53.477304Z
end_timestamp: 2015-06-01T23:24:01.943753Z
+--------------------------+-----------+--------------------------------------------+------------------------------------+-------------------------------+
| id                       | status    | task                                       | action                             | start_timestamp               |
+--------------------------+-----------+--------------------------------------------+------------------------------------+-------------------------------+
| 556cdb7932ed350e9a8834b6 | succeeded | test_stdout_local_script_action            | fixtures.streamwriter-script-local | Mon, 01 Jun 2015 23:23:53 UTC |
| 556cdb7a32ed350e9a8834b9 | succeeded | assert_stdout_field_stdout_test            | asserts.object_key_string_equals   | Mon, 01 Jun 2015 23:23:54 UTC |
| 556cdb7b32ed350e9a8834bc | succeeded | assert_return_code_zero_stdout_test        | asserts.object_key_number_equals   | Mon, 01 Jun 2015 23:23:55 UTC |
| 556cdb7c32ed350e9a8834bf | succeeded | test_stderr_local_script_action            | fixtures.streamwriter-script-local | Mon, 01 Jun 2015 23:23:56 UTC |
| 556cdb7d32ed350e9a8834c2 | succeeded | assert_stderr_field_stderr_test            | asserts.object_key_string_equals   | Mon, 01 Jun 2015 23:23:57 UTC |
| 556cdb7e32ed350e9a8834c5 | succeeded | assert_return_code_zero_stderr_test        | asserts.object_key_number_equals   | Mon, 01 Jun 2015 23:23:58 UTC |
| 556cdb7f32ed350e9a8834c8 | failed    | test_exception_local_script_action         | fixtures.streamwriter-script-local | Mon, 01 Jun 2015 23:23:59 UTC |
| 556cdb8032ed350e9a8834cb | succeeded | assert_return_code_non_zero_exception_test | asserts.object_key_number_greater  | Mon, 01 Jun 2015 23:24:00 UTC |
+--------------------------+-----------+--------------------------------------------+------------------------------------+-------------------------------+
(virtualenv)/m/s/s/st2 git:master ❯❯❯
```
