### PR TITLE
RFR: Add tests for passive sensor

### DIFF
--- a/packs/fixtures/config.yaml
+++ b/packs/fixtures/config.yaml
@@ -1,1 +1,3 @@
 ---
+  host: localhost
+  port: 8888

--- a/packs/fixtures/sensors/test_passive_sensor.py
+++ b/packs/fixtures/sensors/test_passive_sensor.py
@@ -1,0 +1,63 @@
+# Requirements:
+# See ../requirements.txt
+# import datetime
+
+import json
+
+from flask import Flask
+
+from st2reactor.sensor.base import Sensor
+
+SAMPLE_PAYLOAD = {
+    'str': 'String',
+    'int': 1,
+    'boo': True,
+    'obj': {
+        'foo': 'bar',
+        'baz': 1
+    },
+    'lst': [1, 5, 7]
+}
+
+
+class TestPassiveSensor(Sensor):
+    def __init__(self, sensor_service, config=None):
+        super(TestPassiveSensor, self).__init__(sensor_service=sensor_service,
+                                                config=config)
+        self._trigger_pack = 'fixtures'
+        self._trigger_ref = '.'.join([self._trigger_pack, 'test_passive_trigger.dummy'])
+        self.host = self._config['host']
+        self.port = self._config['port']
+        self.app = Flask(__name__)
+
+    def setup(self):
+        @self.app.route('/webhooks/<path:endpoint>', methods=['POST', 'GET'])
+        def handle_ep(endpoint):
+            if endpoint == 'passivesensor/test':
+                return self._handle_webhook(endpoint)
+            else:
+                raise Exception('Unhandled endpoint: %s', endpoint)
+
+    def run(self):
+        # Stopped
+        self.app.run(host=self.host, port=self.port)
+
+    def cleanup(self):
+        pass
+
+    def add_trigger(self, trigger):
+        pass
+
+    def update_trigger(self, trigger):
+        pass
+
+    def remove_trigger(self, trigger):
+        pass
+
+    def _handle_webhook(self, endpoint):
+        self._dispatch_trigger(self._trigger_ref, SAMPLE_PAYLOAD)
+        return json.dumps(SAMPLE_PAYLOAD)
+
+    def _dispatch_trigger(self, trigger, data):
+        # data['timestamp'] = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        self._sensor_service.dispatch(trigger, data)

--- a/packs/fixtures/sensors/test_passive_sensor.yaml
+++ b/packs/fixtures/sensors/test_passive_sensor.yaml
@@ -1,0 +1,21 @@
+---
+  class_name: "TestPassiveSensor"
+  entry_point: "test_passive_sensor.py"
+  description: "Test passive sensor"
+  poll_interval: 5
+  trigger_types:
+    -
+      name: "test_passive_trigger.dummy"
+      payload_schema:
+        type: "object"
+        properties:
+          str:
+            type: "string"
+          int:
+            type: "number"
+          obj:
+            type: "object"
+          lst:
+            type: "array"
+          boo:
+            type: "boolean"

--- a/packs/tests/actions/chains/test_quickstart_passive_sensor.yaml
+++ b/packs/tests/actions/chains/test_quickstart_passive_sensor.yaml
@@ -1,0 +1,40 @@
+---
+chain:
+  -
+    name: "submit_webhook_to_sensor"
+    ref: "core.local"
+    params:
+        env:
+            ST2_AUTH_TOKEN: "{{token}}"
+        cmd: "curl http://127.0.0.1:8888/webhooks/passivesensor/test -H 'Content-Type: application/json'"
+    on-success: "list_last_trigger_instance_emitted"
+  -
+    name: "list_last_trigger_instance_emitted"
+    ref: "core.local"
+    params:
+        env:
+            ST2_AUTH_TOKEN: "{{token}}"
+        cmd: "st2 triggerinstance list --trigger=fixtures.test_passive_trigger.dummy -n=1 -j -a id | grep id | awk '{print $2}'"
+    on-success: "get_last_trigger_instance"
+  -
+    name: "get_last_trigger_instance"
+    ref: "core.local"
+    params:
+        env:
+            ST2_AUTH_TOKEN: "{{token}}"
+        cmd: "st2 triggerinstance get {{ list_last_trigger_instance_emitted.stdout }} -j -a payload"
+    on-success: "assert_trigger_instance_payload_matches_expected"
+  -
+    name: "assert_trigger_instance_payload_matches_expected"
+    ref: "asserts.object_equals"
+    params:
+        object: "{{ get_last_trigger_instance.stdout }}"
+        expected:
+            payload:
+                str: "String"
+                int: 1
+                boo: true
+                obj:
+                    foo: "bar"
+                    baz: 1
+                lst: [1, 5, 7]

--- a/packs/tests/actions/test_quickstart_passive_sensor.yaml
+++ b/packs/tests/actions/test_quickstart_passive_sensor.yaml
@@ -1,0 +1,12 @@
+---
+# Action definition metadata
+name: "test_quickstart_passive_sensor"
+description: "Workflow tests passive sensor on Quick Start"
+runner_type: "action-chain"
+enabled: true
+entry_point: "chains/test_quickstart_passive_sensor.yaml"
+parameters:
+  token:
+    type: "string"
+    description: "st2 auth token"
+    default: ""


### PR DESCRIPTION
## Caught bug https://github.com/StackStorm/st2/pull/1548 already. WooHoo!

```
(virtualenv)/m/s/s/st2 git:set_poll_interval_only_for_polling_sensors ❯❯❯ st2 run tests.test_quickstart_passive_sensor                                                                                                                                     ✭ ◼
...
id: 556f4f3d32ed355f375fe4d6
action.ref: tests.test_quickstart_passive_sensor
status: succeeded
start_timestamp: 2015-06-03T20:02:21.505682Z
end_timestamp: 2015-06-03T20:02:25.744625Z
+--------------------------+-----------+-----------------------------------------------+-----------------------+-------------------------------+
| id                       | status    | task                                          | action                | start_timestamp               |
+--------------------------+-----------+-----------------------------------------------+-----------------------+-------------------------------+
| 556f4f3d32ed355f3bff7f38 | succeeded | submit_webhook_to_sensor                      | core.local            | Wed, 03 Jun 2015 20:02:21 UTC |
| 556f4f3e32ed355f3bff7f3b | succeeded | list_last_trigger_instance_emitted            | core.local            | Wed, 03 Jun 2015 20:02:22 UTC |
| 556f4f3f32ed355f3bff7f3e | succeeded | get_last_trigger_instance                     | core.local            | Wed, 03 Jun 2015 20:02:23 UTC |
| 556f4f4032ed355f3bff7f41 | succeeded | assert_trigger_instance_payload_matches_expec | asserts.object_equals | Wed, 03 Jun 2015 20:02:24 UTC |
|                          |           | ted                                           |                       |                               |
+--------------------------+-----------+-----------------------------------------------+-----------------------+-------------------------------+
(virtualenv)/m/s/s/st2 git:set_poll_interval_only_for_polling_sensors ❯❯❯ st2 execution get 556f4f3e32ed355f3bff7f3b                                                                                                                                       ✭ ◼
id: 556f4f3e32ed355f3bff7f3b
status: succeeded
result:
{
    "failed": false,
    "stderr": "",
    "return_code": 0,
    "succeeded": true,
    "stdout": "556f4f3d32ed355f427dcb86"
}
(virtualenv)/m/s/s/st2 git:set_poll_interval_only_for_polling_sensors ❯❯❯ st2 triggerinstance get 556f4f3d32ed355f427dcb86                                                                                                                                 ✭ ◼
+-----------------+-------------------------------------+
| Property        | Value                               |
+-----------------+-------------------------------------+
| id              | 556f4f3d32ed355f427dcb86            |
| trigger         | fixtures.test_passive_trigger.dummy |
| occurrence_time | 2015-06-03T19:02:21.671000Z         |
| payload         | {                                   |
|                 |     "int": 1,                       |
|                 |     "lst": [                        |
|                 |         1,                          |
|                 |         5,                          |
|                 |         7                           |
|                 |     ],                              |
|                 |     "obj": {                        |
|                 |         "foo": "bar",               |
|                 |         "baz": 1                    |
|                 |     },                              |
|                 |     "str": "String",                |
|                 |     "boo": true                     |
|                 | }                                   |
+-----------------+-------------------------------------+
(virtualenv)/m/s/s/st2 git:set_poll_interval_only_for_polling_sensors ❯❯❯
```