### PR TITLE
Bump sleep to 10 seconds after rule creation.

### DIFF
--- a/packs/tests/actions/chains/test_quickstart_rules.yaml
+++ b/packs/tests/actions/chains/test_quickstart_rules.yaml
@@ -36,7 +36,7 @@ chain:
         params:
             env:
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "sleep 5"
+            cmd: "sleep 10"
         on-success: test_webhook_list    
     -
         name: test_webhook_list


### PR DESCRIPTION
Give some time for the webhook to get created.