### PR TITLE
RFR: Add tests for sudo and quirky arguments

### DIFF
--- a/packs/fixtures/actions/streamwriter-script-local.yaml
+++ b/packs/fixtures/actions/streamwriter-script-local.yaml
@@ -18,7 +18,7 @@ parameters:
     type: object
     description: Some object arg.
   sudo:
-    immutable: true
+    immutable: false
   kwarg_op:
     immutable: true
 runner_type: "local-shell-script"

--- a/packs/fixtures/actions/streamwriter-script-remote.yaml
+++ b/packs/fixtures/actions/streamwriter-script-remote.yaml
@@ -18,7 +18,7 @@ parameters:
     type: object
     description: Some object arg.
   sudo:
-    immutable: true
+    immutable: false
   kwarg_op:
     immutable: true
 runner_type: "remote-shell-script"

--- a/packs/tests/actions/chains/test_quickstart_local_script_actions.yaml
+++ b/packs/tests/actions/chains/test_quickstart_local_script_actions.yaml
@@ -5,10 +5,10 @@ chain:
     ref: "fixtures.streamwriter-script-local"
     params:
         stream: "stdout"
-        str_arg: "foo"
+        str_arg: "foo bar\nbaz"
         int_arg: 1
         obj_arg:
-            foo: bar
+            foo: "bar baz"
     on-success: "assert_stdout_field_stdout_test"
   -
     name: "assert_stdout_field_stdout_test"
@@ -16,7 +16,7 @@ chain:
     params:
         object: "{{test_stdout_local_script_action}}"
         key: "stdout"
-        value: "STREAM IS STDOUT. STR: foo INT: 1 OBJ: {u'foo': u'bar'}"
+        value: "STREAM IS STDOUT. STR: foo bar\nbaz INT: 1 OBJ: {u'foo': u'bar baz'}"
     on-success: "assert_return_code_zero_stdout_test"
   -
     name: "assert_return_code_zero_stdout_test"
@@ -61,3 +61,22 @@ chain:
         object: "{{test_exception_local_script_action}}"
         key: "return_code"
         value: 0
+    on-success: "test_stdout_local_script_action_sudo"
+  -
+    name: "test_stdout_local_script_action_sudo"
+    ref: "fixtures.streamwriter-script-local"
+    params:
+        stream: "stdout"
+        str_arg: "foo bar\nbaz"
+        int_arg: 1
+        obj_arg:
+            foo: "bar baz"
+        sudo:  true
+    on-success: "assert_stdout_field_stdout_test_sudo"
+  -
+    name: "assert_stdout_field_stdout_test_sudo"
+    ref: "asserts.object_key_string_equals"
+    params:
+        object: "{{test_stdout_local_script_action_sudo}}"
+        key: "stdout"
+        value: "STREAM IS STDOUT. STR: foo bar\nbaz INT: 1 OBJ: {u'foo': u'bar baz'}"

--- a/packs/tests/actions/chains/test_quickstart_remote_script_actions.yaml
+++ b/packs/tests/actions/chains/test_quickstart_remote_script_actions.yaml
@@ -6,10 +6,10 @@ chain:
     params:
         stream: "stdout"
         hosts: "localhost"
-        str_arg: "foo"
+        str_arg: "foo bar\nbaz"
         int_arg: 1
         obj_arg:
-            foo: bar
+            foo: "bar baz"
     on-success: "assert_stdout_field_stdout_test"
   -
     name: "assert_stdout_field_stdout_test"
@@ -17,7 +17,7 @@ chain:
     params:
         object: "{{test_stdout_remote_script_action.localhost}}"
         key: "stdout"
-        value: "STREAM IS STDOUT. STR: foo INT: 1 OBJ: {u'foo': u'bar'}"
+        value: "STREAM IS STDOUT. STR: foo bar\nbaz INT: 1 OBJ: {u'foo': u'bar baz'}"
     on-success: "assert_return_code_zero_stdout_test"
   -
     name: "assert_return_code_zero_stdout_test"
@@ -64,3 +64,23 @@ chain:
         object: "{{test_exception_remote_script_action.localhost}}"
         key: "return_code"
         value: 0
+    on-success: "test_stdout_remote_script_action_sudo"
+  -
+    name: "test_stdout_remote_script_action_sudo"
+    ref: "fixtures.streamwriter-script-remote"
+    params:
+        stream: "stdout"
+        hosts: "localhost"
+        str_arg: "foo bar\nbaz"
+        int_arg: 1
+        obj_arg:
+            foo: "bar baz"
+        sudo: true
+    on-success: "assert_stdout_field_stdout_test_sudo"
+  -
+    name: "assert_stdout_field_stdout_test_sudo"
+    ref: "asserts.object_key_string_equals"
+    params:
+        object: "{{test_stdout_remote_script_action_sudo.localhost}}"
+        key: "stdout"
+        value: "STREAM IS STDOUT. STR: foo bar\nbaz INT: 1 OBJ: {u'foo': u'bar baz'}"


### PR DESCRIPTION
```
(virtualenv)/m/s/s/st2 git:pos_args_quoting ❯❯❯ st2 run tests.test_quickstart_remote_script_actions                    ⏎ ✭ ◼
..........
id: 55d77e0332ed35092250bb70
action.ref: tests.test_quickstart_remote_script_actions
status: succeeded
start_timestamp: 2015-08-21T19:37:39.623621Z
end_timestamp: 2015-08-21T19:37:58.655007Z
+--------------------------+-----------+---------------------+---------------------+---------------------+
| id                       | status    | task                | action              | start_timestamp     |
+--------------------------+-----------+---------------------+---------------------+---------------------+
| 55d77e0332ed35092608b2e6 | succeeded | test_stdout_remote_ | fixtures            | Fri, 21 Aug 2015    |
|                          |           | script_action       | .streamwriter-      | 19:37:39 UTC        |
|                          |           |                     | script-remote       |                     |
| 55d77e0732ed35092608b2e9 | succeeded | assert_stdout_field | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | _stdout_test        | string_equals       | 19:37:43 UTC        |
| 55d77e0832ed35092608b2ec | succeeded | assert_return_code_ | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | zero_stdout_test    | number_equals       | 19:37:44 UTC        |
| 55d77e0932ed35092608b2ef | succeeded | test_stderr_remote_ | fixtures            | Fri, 21 Aug 2015    |
|                          |           | script_action       | .streamwriter-      | 19:37:45 UTC        |
|                          |           |                     | script-remote       |                     |
| 55d77e0c32ed35092608b2f2 | succeeded | assert_stderr_field | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | _stderr_test        | string_equals       | 19:37:48 UTC        |
| 55d77e0e32ed35092608b2f5 | succeeded | assert_return_code_ | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | zero_stderr_test    | number_equals       | 19:37:50 UTC        |
| 55d77e0f32ed35092608b2f8 | failed    | test_exception_remo | fixtures            | Fri, 21 Aug 2015    |
|                          |           | te_script_action    | .streamwriter-      | 19:37:51 UTC        |
|                          |           |                     | script-remote       |                     |
| 55d77e1132ed35092608b2fb | succeeded | assert_return_code_ | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | non_zero_exception_ | number_greater      | 19:37:53 UTC        |
|                          |           | test                |                     |                     |
| 55d77e1232ed35092608b2fe | succeeded | test_stdout_remote_ | fixtures            | Fri, 21 Aug 2015    |
|                          |           | script_action_sudo  | .streamwriter-      | 19:37:54 UTC        |
|                          |           |                     | script-remote       |                     |
| 55d77e1432ed35092608b301 | succeeded | assert_stdout_field | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | _stdout_test_sudo   | string_equals       | 19:37:56 UTC        |
+--------------------------+-----------+---------------------+---------------------+---------------------+
(virtualenv)/m/s/s/st2 git:pos_args_quoting ❯❯❯ st2 run tests.test_quickstart_local_script_actions                       ✭ ◼
.......
id: 55d77e7732ed35092250bb73
action.ref: tests.test_quickstart_local_script_actions
status: succeeded
start_timestamp: 2015-08-21T19:39:35.753263Z
end_timestamp: 2015-08-21T19:39:48.564032Z
+--------------------------+-----------+---------------------+---------------------+---------------------+
| id                       | status    | task                | action              | start_timestamp     |
+--------------------------+-----------+---------------------+---------------------+---------------------+
| 55d77e7732ed35092608b314 | succeeded | test_stdout_local_s | fixtures            | Fri, 21 Aug 2015    |
|                          |           | cript_action        | .streamwriter-      | 19:39:35 UTC        |
|                          |           |                     | script-local        |                     |
| 55d77e7832ed35092608b317 | succeeded | assert_stdout_field | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | _stdout_test        | string_equals       | 19:39:36 UTC        |
| 55d77e7a32ed35092608b31b | succeeded | assert_return_code_ | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | zero_stdout_test    | number_equals       | 19:39:38 UTC        |
| 55d77e7c32ed35092608b31e | succeeded | test_stderr_local_s | fixtures            | Fri, 21 Aug 2015    |
|                          |           | cript_action        | .streamwriter-      | 19:39:39 UTC        |
|                          |           |                     | script-local        |                     |
| 55d77e7d32ed35092608b321 | succeeded | assert_stderr_field | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | _stderr_test        | string_equals       | 19:39:41 UTC        |
| 55d77e7e32ed35092608b324 | succeeded | assert_return_code_ | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | zero_stderr_test    | number_equals       | 19:39:42 UTC        |
| 55d77e8032ed35092608b328 | failed    | test_exception_loca | fixtures            | Fri, 21 Aug 2015    |
|                          |           | l_script_action     | .streamwriter-      | 19:39:44 UTC        |
|                          |           |                     | script-local        |                     |
| 55d77e8132ed35092608b32b | succeeded | assert_return_code_ | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | non_zero_exception_ | number_greater      | 19:39:45 UTC        |
|                          |           | test                |                     |                     |
| 55d77e8232ed35092608b32e | succeeded | test_stdout_local_s | fixtures            | Fri, 21 Aug 2015    |
|                          |           | cript_action_sudo   | .streamwriter-      | 19:39:46 UTC        |
|                          |           |                     | script-local        |                     |
| 55d77e8332ed35092608b332 | succeeded | assert_stdout_field | asserts.object_key_ | Fri, 21 Aug 2015    |
|                          |           | _stdout_test_sudo   | string_equals       | 19:39:47 UTC        |
+--------------------------+-----------+---------------------+---------------------+---------------------+
(virtualenv)/m/s/s/st2 git:pos_args_quoting ❯❯❯
```