### PR TITLE
Add missing flask requirements to the fixtures pack

### DIFF
--- a/packs/fixtures/requirements.txt
+++ b/packs/fixtures/requirements.txt
@@ -1,1 +1,2 @@
-
+flask
+flask-jsonschema


### PR DESCRIPTION
I've merged packaging changes into master and st2_deploy_test "magically" failed.

It turns out, passive sensor depends on the flask library which is not listed in the requirements therefor it's not available for the sensor and the sensor can't start.

Previously it worked because global requirements.txt file listed flask as a requirement even though none of the st2 code actually used it.