### PR TITLE
[RFR] ChatOps self-check fix

### DIFF
--- a/robotfm_tests/chatops_self_check.rst
+++ b/robotfm_tests/chatops_self_check.rst
@@ -1,11 +1,5 @@
+
 .. code:: robotframework
-
-
-    *** Variables ***
-    ${ST2}                /usr/bin/st2
-    ${SUCCESS}            Everything seems to be fine!!
-    ${FAILURE}            Uh oh! Something went wrong!
-    ${HUBOT HELP}         {  echo  -n;  sleep  5;  echo  'hubot  help';  echo;  sleep  2;}  |  bin\/hubot  \-\-test
 
 
     *** Test Cases ***
@@ -14,58 +8,83 @@
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}    st2 execution get
         # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2 NOT RUNNING
-
+    
     Check for st2chatops service
-        ${result}=       Run Process    service  st2chatops  status
-        Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
+        ${result}=                   Run Process    service  st2chatops  status
+        Log To Console               \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Be Equal As Integers  ${result.rc}   0
         # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2CHATOPS NOT INSTALLED ON THIS MACHINE
-
+    
     Hubot npm
         ${result}=       Run Process    npm   list    \|  grep  hubot-stackstorm  cwd=/opt/stackstorm/chatops
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  hubot-stackstorm@
         # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT-STACKSTORM IS NOT INSTALLED
-
+    
     Check for enabled StackStorm aliases
         ${result}=       Run Process      st2  action-alias   list  -a  enabled  -j
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  "enabled": true
         # Run Keyword If   ${result.rc} != 0   Fatal Error  StackStorm doesn't seem to have registered and enabled aliases.
-
+    
     Check chatops.notify rule
         ${result}=       Run Process   st2  rule  list  -p  chatops  -j
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  "ref": "chatops.notify"
         Should Contain   ${result.stdout}  "enabled": true
         # Run Keyword If   ${result.rc} != 0   Fatal Error   CHATOPS.NOTIFY RULE NOT PRESENT/ENABLED
-
+    
     Check Hubot help and load commands
-        ${result}=       Run Process     ${HUBOT HELP}   cwd=/opt/stackstorm/chatops/  shell=True
+        ${result}=       Run Keyword  Hubot Help 
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}    ! help - Displays all of the help commands
         Should Contain   ${result.stdout}    commands are loaded
         # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT DOESN'T RESPOND TO THE "HELP" COMMAND OR DOESN'T TRY TO LOAD COMMANDS FROM STACKSTORM.
-
-
+    
+    
     Check post_message execution and receive status
-        ${channel}=       Generate Random String  32
+        ${channel}=       Generate Token 
         Log To Console   \nCHANNEL: ${channel}
-        ${result}=       Run Process    {  echo  -n;  sleep  5;  st2  action  execute  chatops.post_message  channel\=${channel}   message\='Debug. If you see this you are incredibly lucky but please ignore.'  >\/dev\/null;  echo;  sleep  2;}  \|  bin\/hubot  \-\-test   cwd=/opt/stackstorm/chatops/    shell=True
+        ${result}=       Run Keyword  Hubot Post  ${channel}
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}   Chatops message received
         Should Contain   ${result.stdout}   ${channel}
         # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE HASN'T BEEN RECEIVED.
-
+    
     Check the complete request-response flow
-        ${channel}=       Generate Random String  32
+        ${channel}=      Generate Token
         Log To Console   \nCHANNEL: ${channel}
-        ${result}=       Run Process    {  echo  -n;  sleep  5;  echo  'hubot  st2  list  5  actions  pack\=st2';  echo;  sleep  10;}  \|  bin\/hubot  \-\-test   cwd=/opt/stackstorm/chatops/    shell=True
+        ${result}=       Run Keyword  Complete Flow  ${channel} 
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}   Give me just a moment to find the actions for you
         Should Contain   ${result.stdout}   st2.actions.list - Retrieve a list of available StackStorm actions.
         # Run Keyword If   ${result.rc} != 0    Fatal Error  END-TO-END TEST FAILED.
 
+
+    *** Keyword ***
+    Hubot Help
+        ${result}=     Run Process    {  echo  -n;  sleep  5;  echo  'hubot  help';  echo;  sleep  2;}  |  bin\/hubot  \-\-test
+        ...                           cwd=/opt/stackstorm/chatops/  shell=True
+        [return]      ${result}
+
+    Hubot Post
+        [Arguments]    ${channel}
+        ${result}=     Run Process    {  echo  -n;  sleep  5;  st2  action  execute  chatops.post_message  channel\=${channel}
+        ...                           message\='Debug. If you see this you are incredibly lucky but please ignore.'
+        ...                           >\/dev\/null;  echo;  sleep  2;}  |  bin\/hubot  \-\-test
+        ...                           cwd=/opt/stackstorm/chatops/    shell=True
+        [return]       ${result}
+    
+    Complete Flow
+        [Arguments]    ${channel}
+        ${result}=     Run Process  {  echo  -n;  sleep  5;  echo  'hubot  st2  list  5  actions  pack\=st2';  echo;  sleep  10;}
+        ...                         |  bin\/hubot  \-\-test   cwd=/opt/stackstorm/chatops/    shell=True
+        [return]       ${result}
+
+    Generate Token
+        ${token}=       Generate Random String  32
+        [return]        ${token}
+    
 
     *** Settings ***
     Documentation    Nine-Step Hubot Self-Check Program

--- a/robotfm_tests/chatops_self_check.rst
+++ b/robotfm_tests/chatops_self_check.rst
@@ -1,4 +1,3 @@
-
 .. code:: robotframework
 
 
@@ -8,49 +7,49 @@
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}    st2 execution get
         # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2 NOT RUNNING
-    
+
     Check for st2chatops service
-        ${result}=                   Run Process    service  st2chatops  status
-        Log To Console               \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
-        Should Be Equal As Integers  ${result.rc}   0
+        ${result}=         Run Process    service  st2chatops  status
+        Log To Console     \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
+        Should Be Equal    ${result.rc}   ${0}
         # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2CHATOPS NOT INSTALLED ON THIS MACHINE
-    
+
     Hubot npm
         ${result}=       Run Process    npm   list    \|  grep  hubot-stackstorm  cwd=/opt/stackstorm/chatops
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  hubot-stackstorm@
         # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT-STACKSTORM IS NOT INSTALLED
-    
+
     Check for enabled StackStorm aliases
         ${result}=       Run Process      st2  action-alias   list  -a  enabled  -j
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  "enabled": true
         # Run Keyword If   ${result.rc} != 0   Fatal Error  StackStorm doesn't seem to have registered and enabled aliases.
-    
+
     Check chatops.notify rule
         ${result}=       Run Process   st2  rule  list  -p  chatops  -j
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  "ref": "chatops.notify"
         Should Contain   ${result.stdout}  "enabled": true
         # Run Keyword If   ${result.rc} != 0   Fatal Error   CHATOPS.NOTIFY RULE NOT PRESENT/ENABLED
-    
+
     Check Hubot help and load commands
         ${result}=       Run Keyword  Hubot Help 
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}    ! help - Displays all of the help commands
         Should Contain   ${result.stdout}    commands are loaded
         # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT DOESN'T RESPOND TO THE "HELP" COMMAND OR DOESN'T TRY TO LOAD COMMANDS FROM STACKSTORM.
-    
-    
+
+
     Check post_message execution and receive status
-        ${channel}=       Generate Token 
+        ${channel}=       Generate Token
         Log To Console   \nCHANNEL: ${channel}
         ${result}=       Run Keyword  Hubot Post  ${channel}
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}   Chatops message received
         Should Contain   ${result.stdout}   ${channel}
         # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE HASN'T BEEN RECEIVED.
-    
+
     Check the complete request-response flow
         ${channel}=      Generate Token
         Log To Console   \nCHANNEL: ${channel}
@@ -74,7 +73,7 @@
         ...                           >\/dev\/null;  echo;  sleep  2;}  |  bin\/hubot  \-\-test
         ...                           cwd=/opt/stackstorm/chatops/    shell=True
         [return]       ${result}
-    
+
     Complete Flow
         [Arguments]    ${channel}
         ${result}=     Run Process  {  echo  -n;  sleep  5;  echo  'hubot  st2  list  5  actions  pack\=st2';  echo;  sleep  10;}
@@ -84,7 +83,7 @@
     Generate Token
         ${token}=       Generate Random String  32
         [return]        ${token}
-    
+
 
     *** Settings ***
     Documentation    Nine-Step Hubot Self-Check Program

--- a/robotfm_tests/chatops_self_check.rst
+++ b/robotfm_tests/chatops_self_check.rst
@@ -57,6 +57,15 @@
         Should Contain   ${result.stdout}   ${channel}
         # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE HASN'T BEEN RECEIVED.
 
+    Check the complete request-response flow
+        ${channel}=       Generate Random String  32
+        Log To Console   \nCHANNEL: ${channel}
+        ${result}=       Run Process    {  echo  -n;  sleep  5;  echo  'hubot  st2  list  5  actions  pack\=st2';  echo;  sleep  10;}  \|  bin\/hubot  \-\-test   cwd=/opt/stackstorm/chatops/    shell=True
+        Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
+        Should Contain   ${result.stdout}   Give me just a moment to find the actions for you
+        Should Contain   ${result.stdout}   st2.actions.list - Retrieve a list of available StackStorm actions.
+        # Run Keyword If   ${result.rc} != 0    Fatal Error  END-TO-END TEST FAILED.
+
 
     *** Settings ***
     Documentation    Nine-Step Hubot Self-Check Program

--- a/robotfm_tests/chatops_self_check.rst
+++ b/robotfm_tests/chatops_self_check.rst
@@ -5,9 +5,7 @@
     ${ST2}                /usr/bin/st2
     ${SUCCESS}            Everything seems to be fine!!
     ${FAILURE}            Uh oh! Something went wrong!
-    ${TEST CHANNEL}       Generate Random String  32
     ${HUBOT HELP}         {  echo  -n;  sleep  5;  echo  'hubot  help';  echo;  sleep  2;}  |  bin\/hubot  \-\-test
-    ${HUBOT POST}         {  echo  -n;  sleep  5;  st2 action execute chatops.post_message channel\=${TEST CHANNEL}  message\='Debug. If you see this you are incredibly lucky but please ignore.' >\/dev\/null;  echo;  sleep  2;}  |  bin\/hubot  \-\-test
 
 
     *** Test Cases ***
@@ -51,11 +49,12 @@
 
 
     Check post_message execution and receive status
-        Log To Console   \nCHANNEL: ${TEST CHANNEL}
-        ${result}=       Run Process    ${HUBOT POST}   cwd=/opt/stackstorm/chatops/    shell=True
+        ${channel}=       Generate Random String  32
+        Log To Console   \nCHANNEL: ${channel}
+        ${result}=       Run Process    {  echo  -n;  sleep  5;  st2  action  execute  chatops.post_message  channel\=${channel}   message\='Debug. If you see this you are incredibly lucky but please ignore.'  >\/dev\/null;  echo;  sleep  2;}  \|  bin\/hubot  \-\-test   cwd=/opt/stackstorm/chatops/    shell=True
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}   Chatops message received
-        Should Contain   ${result.stdout}   ${TEST CHANNEL}
+        Should Contain   ${result.stdout}   ${channel}
         # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE HASN'T BEEN RECEIVED.
 
 

--- a/robotfm_tests/chatops_self_check.rst
+++ b/robotfm_tests/chatops_self_check.rst
@@ -2,27 +2,29 @@
 
 
     *** Variables ***
-    ${ST2}                /usr/bin/st2 
+    ${ST2}                /usr/bin/st2
     ${SUCCESS}            Everything seems to be fine!!
-    ${FAILURE}            Uh oh! Something went wrong! 
-    ${HUBOT HELP}          {  echo  -n;  sleep  5;  echo  'hubot  help';  echo;  sleep  2;}  |  bin\/hubot  \-\-test 
-    
-    
+    ${FAILURE}            Uh oh! Something went wrong!
+    ${TEST CHANNEL}       Generate Random String  32
+    ${HUBOT HELP}         {  echo  -n;  sleep  5;  echo  'hubot  help';  echo;  sleep  2;}  |  bin\/hubot  \-\-test
+    ${HUBOT POST}         {  echo  -n;  sleep  5;  st2 action execute chatops.post_message channel\=${TEST CHANNEL}  message\='Debug. If you see this you are incredibly lucky but please ignore.' >\/dev\/null;  echo;  sleep  2;}  |  bin\/hubot  \-\-test
+
+
     *** Test Cases ***
     Stackstorm client's connection
         ${result}=       Run Process    st2  action  execute  core.local   cmd\=echo
-        Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}    
+        Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}    st2 execution get
         # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2 NOT RUNNING
 
-    Check Hubot installation and status
+    Check for st2chatops service
         ${result}=       Run Process    service  st2chatops  status
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
-        Should Contain   ${result.stdout}  st2chatops start/running
-        # Run Keyword If   ${result.rc} != 0   Fatal Error    HUBOT NOT RUNNING ON THIS MACHINE   
+        Should Be Equal As Integers  ${result.rc}   0
+        # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2CHATOPS NOT INSTALLED ON THIS MACHINE
 
     Hubot npm
-        ${result}=       Run Process    npm   list    \|  grep  hubot-stackstorm  cwd=/opt/stackstorm/chatops 
+        ${result}=       Run Process    npm   list    \|  grep  hubot-stackstorm  cwd=/opt/stackstorm/chatops
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  hubot-stackstorm@
         # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT-STACKSTORM IS NOT INSTALLED
@@ -31,7 +33,7 @@
         ${result}=       Run Process      st2  action-alias   list  -a  enabled  -j
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}  "enabled": true
-        # Run Keyword If   ${result.rc} != 0   Fatal Error  StackStorm doesn't seem to have registered and enabled aliases. 
+        # Run Keyword If   ${result.rc} != 0   Fatal Error  StackStorm doesn't seem to have registered and enabled aliases.
 
     Check chatops.notify rule
         ${result}=       Run Process   st2  rule  list  -p  chatops  -j
@@ -42,25 +44,19 @@
 
     Check Hubot help and load commands
         ${result}=       Run Process     ${HUBOT HELP}   cwd=/opt/stackstorm/chatops/  shell=True
-        Sleep  15s
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
         Should Contain   ${result.stdout}    ! help - Displays all of the help commands
         Should Contain   ${result.stdout}    commands are loaded
-        # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT DOESN'T RESPOND TO THE "HELP" COMMAND OR DOESN'T TRY TO LOAD COMMANDS FROM STACKSTORM. 
+        # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT DOESN'T RESPOND TO THE "HELP" COMMAND OR DOESN'T TRY TO LOAD COMMANDS FROM STACKSTORM.
 
 
     Check post_message execution and receive status
-        ${channel}=       Generate Random String  32
-        Log To Console   \nCHANNEL: ${channel}
-        ${result}=       Run Process  st2  action  execute  chatops.post_message  channel\=${channel}  message\=Debug. If you see this you're incredibly lucky but please ignore.
+        Log To Console   \nCHANNEL: ${TEST CHANNEL}
+        ${result}=       Run Process    ${HUBOT POST}   cwd=/opt/stackstorm/chatops/    shell=True
         Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
-        Should Contain   ${result.stdout}   execution get
-        # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE DOESN'T WORK. 
-        Sleep  2s
-        ${result}=       Run Process  tail  \/var\/log\/st2\/st2chatops.log  shell=True
-        Log To Console   \nSTDOUT: ${result.stdout} \nSTDERR: ${result.stderr} \nRC ${result.rc}
-        Should Contain   ${result.stdout}   ${channel}
-        # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE HASN'T BEEN RECEIVED. 
+        Should Contain   ${result.stdout}   Chatops message received
+        Should Contain   ${result.stdout}   ${TEST CHANNEL}
+        # Run Keyword If   ${result.rc} != 0    Fatal Error  CHATOPS.POST_MESSAGE HASN'T BEEN RECEIVED.
 
 
     *** Settings ***


### PR DESCRIPTION
@humblearner added some chatops testing functionality to Robot framework, but a few cases is broken, and one needs to be added. 

Fixed:
1. Now checking for st2chatops service being present, not hubot running. Even if the service is stopped, it’s still there, so the test should pass.

To do:
1. Fix the `post_message` check. There’s a problem with it that I can’t put my finger on.
2. Add an end-to-end scenario: alias launch with tracking of the result in Hubot.