### PR TITLE
Update affected packs tests for the configs change

### DIFF
--- a/packs/tests/actions/chains/test_packs_pack.yaml
+++ b/packs/tests/actions/chains/test_packs_pack.yaml
@@ -161,7 +161,8 @@ chain:
               ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 run packs.load register=all | grep -c 'Registered' | grep 6"
+            # sensors, actions, rules, aliases, policy types, policies, configs -> 7
+            cmd: "st2 run packs.load register=all | grep -c 'Registered' | grep 7"
         on-success: test_pack_install_with_no_config
         on-failure: error_handler
     -


### PR DESCRIPTION
Now configs are also registered so "Registered" is printed 7 times.