### PR TITLE
Fix for chatopsCI and quickstart_sample_rule_with_webhook

### DIFF
--- a/robotfm_tests/chatopsCI/chatops_slack_check.rst
+++ b/robotfm_tests/chatopsCI/chatops_slack_check.rst
@@ -66,24 +66,27 @@
         Should Contain      ${result.stdout}  details available at
         Should Contain      ${result.stdout}  in channel: chatopsci, from: grobgobglobgrod
         @{output}  Get Regexp Matches   ${result.stdout}  (?ms)result :\n--------\nresult :(.*?)in channel: chatopsci, from: grobgobglobgrod
+        Set Suite Variable  ${status}  Invalid chatops.post_message ID
         :FOR    ${ELEMENT}    IN    @{output}
-        # \    Log To Console  \n++=========++\n
-        \    ${matched regex}=      Get Lines Containing String  ${ELEMENT}  matched regex
-        \    ${length}=  Get Length  ${matched regex}
-        \    Run Keyword if  ${length} == 0   Set Suite Variable  ${ELEMENT}
-        \    Run Keyword if  ${length} == 0   Verify Correct Substring
-
-
+        \    Log To Console  \n++=========++\n
+        \    ${regex}=      Get Lines Containing String  ${ELEMENT}  matched regex
+        \    ${length}=  Get Length  ${regex}
+        \    Run Keyword if    ${length} == 0 and "id : ${EXECUTION ID}" in '''${ELEMENT}'''  Verify Correct Substring  ${ELEMENT}
+        \    Log To console  Status: ${status}
+        Pass execution if  '''${status}''' == "Valid chatops.post_message ID"  PASS
+        Should Be Equal  ${status}  Valid chatops.post_message ID
 
 
 
 
     *** Keyword ***
     Verify Correct Substring
+        [Arguments]     ${ELEMENT}
         Log To Console   \nSUBSTRING:\n------------\n${ELEMENT}\n------------\n
         Should Contain   ${ELEMENT}  in channel: chatopsci, from: grobgobglobgro
         Should Contain   ${ELEMENT}  ref : chatops.post_message
         Should Contain   ${ELEMENT}  id : ${EXECUTION ID}
+        Set Suite Variable   ${status}  Valid chatops.post_message ID
 
     Replace the token for slack with slackcat in st2chatops.env
        ${result}=       Run Process  sudo  sed  -i  -e  's/export  HUBOT_SLACK_TOKEN\=${HUBOT_SLACK_TOKEN}/

--- a/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
+++ b/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
@@ -34,8 +34,8 @@
     Verify error message for duplicate rule
         ${result}=       Run Process    st2  rule  create  /usr/share/doc/st2/examples/rules/sample_rule_with_webhook.yaml  -j
         Should Contain   ${result.stdout}  ERROR: 409 Client Error: Conflict
-        Should Contain   ${result.stdout}  MESSAGE: Tried to save duplicate unique keys (E11000 duplicate key error index:
-        ...                                st2.rule_d_b.$uid_1  dup key: { : "rule:examples:sample_rule_with_webhook" }) for url:
+        Should Contain   ${result.stdout}  MESSAGE: Tried to save duplicate unique keys
+        Should Contain   ${result.stdout}  duplicate key error index: st2.rule_d_b.$uid_1  dup key: { : "rule:examples:sample_rule_with_webhook" }) for url:
 
     Verify rule status
         ${TOKEN}=        Run Process    st2  auth  -p  Ch@ngeMe  st2admin  -t  shell=True


### PR DESCRIPTION
1.  ChatopsCI: Fix for atleast 1 valid chatops.post_messageID
2.  Docs: quickstart_sample_rule_with_webhook was filing in RHEL7 `MESSAGE: Tried to save duplicate unique keys (insertDocument :: caused by :: 11000 E11000 duplicate key error index: st2.rule_d_b.$uid_1  dup key: { : "rule:examples:sample_rule_with_webhook" }) for url:`. This is extra in RHEL7: `insertDocument :: caused by :: 11000`