### PR TITLE
Update affected robotfm tests

### DIFF
--- a/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
+++ b/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
@@ -35,7 +35,7 @@
         ${result}=       Run Process    st2  rule  create  /usr/share/doc/st2/examples/rules/sample_rule_with_webhook.yaml  -j
         Should Contain   ${result.stdout}  ERROR: 409 Client Error: Conflict
         Should Contain   ${result.stdout}  MESSAGE: Tried to save duplicate unique keys
-        Should Contain   ${result.stdout}  duplicate key error index: st2.rule_d_b.$uid_1  dup key: { : "rule:examples:sample_rule_with_webhook" }) for url:
+        Should Contain   ${result.stdout}  duplicate key error collection: st2.rule_d_b index: uid_1 dup key:
 
     Verify rule status
         ${TOKEN}=        Run Process    st2  auth  -p  Ch@ngeMe  st2admin  -t  shell=True

--- a/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
+++ b/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
@@ -35,7 +35,7 @@
         ${result}=       Run Process    st2  rule  create  /usr/share/doc/st2/examples/rules/sample_rule_with_webhook.yaml  -j
         Should Contain   ${result.stdout}  ERROR: 409 Client Error: Conflict
         Should Contain   ${result.stdout}  MESSAGE: Tried to save duplicate unique keys
-        Should Contain   ${result.stdout}  duplicate key error collection: st2.rule_d_b index: uid_1 dup key:
+        Should Contain   ${result.stdout}  duplicate key error collection: st2.rule_d_b index: uid_1 dup key: { : "rule:examples:sample_rule_with_webhook" }) for url:
 
     Verify rule status
         ${TOKEN}=        Run Process    st2  auth  -p  Ch@ngeMe  st2admin  -t  shell=True


### PR DESCRIPTION
We have updated to a new version of mongoengine which changes the error message a bit (it not also includes collection name).

> MESSAGE: Tried to save duplicate unique keys (E11000 duplicate key error collection: st2.rule_d_b index: uid_1 dup key: { : "rule:examples:sample_rule_with_webhook" }) for url: http://st2-pkg-unstable-u14-df9e019461.uswest2.stackstorm.net:9101/rules' does not contain 'duplicate key error index: st2.rule_d_b.$uid_1