### PR TITLE
Scope is now st2kv.system and not system

### DIFF
--- a/packs/tests/actions/chains/test_key_triggers.yaml
+++ b/packs/tests/actions/chains/test_key_triggers.yaml
@@ -104,8 +104,8 @@ chain:
                     value: b
                     encrypted: false
                     secret: false
-                    scope: system
-                    uid: "key_value_pair:system:a"
+                    scope: st2kv.system
+                    uid: "key_value_pair:st2kv.system:a"
         on-success: update_key
     -
         name: update_key
@@ -151,15 +151,15 @@ chain:
                     value: c
                     encrypted: false
                     secret: false
-                    scope: system
-                    uid: "key_value_pair:system:a"
+                    scope: st2kv.system
+                    uid: "key_value_pair:st2kv.system:a"
                 old_object:
                     name: a
                     value: b
                     encrypted: false
                     secret: false
-                    scope: system
-                    uid: "key_value_pair:system:a"
+                    scope: st2kv.system
+                    uid: "key_value_pair:st2kv.system:a"
         on-success: check_key_update_trigger_instance
     -
         name: check_key_update_trigger_instance
@@ -194,8 +194,8 @@ chain:
                     value: c
                     encrypted: false
                     secret: false
-                    scope: system
-                    uid: "key_value_pair:system:a"
+                    scope: st2kv.system
+                    uid: "key_value_pair:st2kv.system:a"
         on-success: delete_key
     -
         name: delete_key
@@ -241,6 +241,6 @@ chain:
                     value: c
                     encrypted: false
                     secret: false
-                    scope: system
-                    uid: "key_value_pair:system:a"
+                    scope: st2kv.system
+                    uid: "key_value_pair:st2kv.system:a"
 default: cleanup_environment


### PR DESCRIPTION
Logs from build failure:

```
status: failed
error: u'Input: 
scope:st2kv.system'
u'Expected: 
scope:system'
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2actions/runners/python_action_wrapper.py", line 211, in <module>
    obj.run()
  File "/opt/stackstorm/st2/lib/python2.7/site-packages/st2actions/runners/python_action_wrapper.py", line 126, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/asserts/actions/object_contains.py", line 24, in run
    raise ValueError('Objects not equal. Input: %s, Expected: %s.' % (object, expected))
ValueError: Objects not equal. Input: {u'object': {u'uid': u'key_value_pair:st2kv.system:a', u'encrypted': False, u'value': u'b', u'secret': False, u'scope': u'st2kv.system', u'id': u'57f402e4200b0e5474d64982', u'name': u'a'}}, Expected: {u'object': {u'name': u'a', u'encrypted': False, u'value': u'b', u'secret': False, u'scope': u'system', u'uid': u'key_value_pair:system:a'}}.
```