### PR TITLE
Check for TIMEOUT status with pack install

### DIFF
--- a/robotfm_tests/docs/integration_packs_doc.rst
+++ b/robotfm_tests/docs/integration_packs_doc.rst
@@ -15,6 +15,7 @@
         ${result}=          Run Process  st2  run  packs.install  packs\=${PACK TO INSTALL 1},${PACK TO INSTALL 2}  repo_url\=${BASE REPO URL}/${INSTALL FROM REPO}  -j
         # Log To Console     \nINSTALL: ${result.stdout}
         Should Not Contain  ${result.stdout}   ${FAIL STATUS}
+        Should Not Contain  ${result.stdout}   ${TIMEOUT STATUS}
         ${result}=          Run Process    st2  action  list  --pack  ${PACK TO INSTALL 1}  -j
         # Log To Console     \nLIST: ${result.stdout}
         Should Contain      ${result.stdout}  ${PACK VAR 1}

--- a/robotfm_tests/docs/variables/integration_packs_doc.yaml
+++ b/robotfm_tests/docs/variables/integration_packs_doc.yaml
@@ -6,5 +6,6 @@ INSTALL FROM REPO:           "st2contrib"
 PACK VAR 1:                  '"pack": "libcloud"'
 PACK VAR 2:                  '"pack": "chef"'
 FAIL STATUS:                 '"status": "failed"'
+TIMEOUT STATUS:              '"status": "timeout"'
 SUCCESS STATUS:              '"status": "succeeded"'
 PACK 1 SUCCESS:              '"libcloud": "Success."'


### PR DESCRIPTION
Sometimes, this happens

```
[vagrant@st2test ~]$ st2 run packs.install packs=libcloud,chef
..............................
id: 5820fd2a55fc8c2142f9d1bd
action.ref: packs.install
parameters:
  packs:
  - libcloud
  - chef
status: timeout
start_timestamp: 2016-11-07T22:16:10.583048Z
end_timestamp: 2016-11-07T22:17:11.669506Z
+--------------------------+-----------------------+---------------+----------------+----------------------+
| id                       | status                | task          | action         | start_timestamp      |
+--------------------------+-----------------------+---------------+----------------+----------------------+
| 5820fd2b55fc8c1d0c2100ed | timeout (61s elapsed) | download pack | packs.download | Mon, 07 Nov 2016     |
|                          |                       |               |                | 22:16:10 UTC         |
+--------------------------+-----------------------+---------------+----------------+----------------------+
[vagrant@st2test ~]$
```

And robot ain't do well https://st2-build/#/history/5820fe6027263a079baecda7/general