### PR TITLE
Changing success count from 4 to 3 

### DIFF
--- a/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
+++ b/robotfm_tests/docs/quickstart_sample_rule_with_webhook.rst
@@ -70,7 +70,7 @@
 
     Verify examples pack uninstall
         ${result}=       Run Process  st2  run  packs.uninstall  packs\=examples  -j
-        Should Contain X Times   ${result.stdout}  "status": "succeeded  4
+        Should Contain X Times   ${result.stdout}  "status": "succeeded  3
         Should Contain   ${result.stdout}    "action": "packs.unload"
         Should Contain   ${result.stdout}    "action": "packs.delete"
         Should Contain   ${result.stdout}    "action": "packs.restart_component"
@@ -96,7 +96,7 @@
 
     Remove the examples pack
         ${result}=       Run Process  st2  run  packs.uninstall  packs\=examples  -j
-        Should Contain X Times   ${result.stdout}  "status": "succeeded  4
+        Should Contain X Times   ${result.stdout}  "status": "succeeded  3
         Should Contain   ${result.stdout}    "action": "packs.unload"
         Should Contain   ${result.stdout}    "action": "packs.delete"
         Should Contain   ${result.stdout}    "action": "packs.restart_component"

--- a/robotfm_tests/mistral/mistral_test_cancel.rst
+++ b/robotfm_tests/mistral/mistral_test_cancel.rst
@@ -73,7 +73,7 @@
     Uninstall Examples Pack
         Log To Console   ___________________________SUITE TEARDOWN___________________________
         ${result}=                   Run Process  st2  run  packs.uninstall  packs\=examples  -j
-        Should Contain X Times       ${result.stdout}  ${SUCCESS STATUS}  4
+        Should Contain X Times       ${result.stdout}  ${SUCCESS STATUS}  3
         Directory Should Not Exist  /opt/stackstorm/packs/examples/
 
     *** Settings ***


### PR DESCRIPTION
Since `restart sensor container` was removed from `packs.uninstall` The framework needs to take this change into account for test to pass.