### PR TITLE
Use lower sleep, wait longer when checking execution status

### DIFF
--- a/robotfm_tests/mistral/mistral_test_cancel.rst
+++ b/robotfm_tests/mistral/mistral_test_cancel.rst
@@ -1,7 +1,7 @@
 .. code:: robotframework
 
      *** Variables ***
-     ${SLEEP}             20
+     ${SLEEP}             10
      ${SUCCESS STATUS}    "status": "succeeded
      ${RUNNING STATUS}    "status": "running
      ${CANCELED STATUS}   "status": "canceled"
@@ -24,7 +24,8 @@
          Log To Console       \nEXECUTION CANCEL: \n ${result.stdout}
 
      Check Canceled Execution
-         ${result}=  Wait Until Keyword Succeeds  ${SLEEP}s  1s         Canceled Execution
+         ${Sleep}=   Evaluate  ${SLEEP}+5
+         ${result}=  Wait Until Keyword Succeeds  ${Sleep}s  1s         Canceled Execution
          Log To Console       \nGET EXECUTION AFTER CANCELLATION:\n ${result.stdout}
 
      Executed successfully examples.mistral-test-cancel

--- a/robotfm_tests/mistral/mistral_test_cancel.rst
+++ b/robotfm_tests/mistral/mistral_test_cancel.rst
@@ -1,7 +1,7 @@
 .. code:: robotframework
 
      *** Variables ***
-     ${SLEEP}             10
+     ${SLEEP}             8
      ${SUCCESS STATUS}    "status": "succeeded
      ${RUNNING STATUS}    "status": "running
      ${CANCELED STATUS}   "status": "canceled"
@@ -24,12 +24,12 @@
          Log To Console       \nEXECUTION CANCEL: \n ${result.stdout}
 
      Check Canceled Execution
-         ${Sleep}=   Evaluate  ${SLEEP}+5
+         ${Sleep}=   Evaluate  ${SLEEP}+8
          ${result}=  Wait Until Keyword Succeeds  ${Sleep}s  1s         Canceled Execution
          Log To Console       \nGET EXECUTION AFTER CANCELLATION:\n ${result.stdout}
 
      Executed successfully examples.mistral-test-cancel
-         ${Sleep}=   Evaluate  ${SLEEP}+5
+         ${Sleep}=   Evaluate  ${SLEEP}+8
          ${result}=  Wait Until Keyword Succeeds  ${Sleep}s  1s  Final Execution
          Log To Console       \nGET EXECUTION AFTER COMPLETION: \n ${result.stdout}
 


### PR DESCRIPTION
* Use lower sleep so tests finish earlier
* Wait longer (sleep + 5s of grace period) before check if execution has been canceled