### PR TITLE
Fix "test_timer_rule" in Ubuntu Xenial

### DIFF
--- a/packs/tests/actions/chains/test_timer_rule.yaml
+++ b/packs/tests/actions/chains/test_timer_rule.yaml
@@ -38,7 +38,7 @@ chain:
               ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "sleep `echo {{ tested_triggers  }}*{{ tested_interval }}+{{ tested_interval }}-1 | bc`"
+            cmd: "sleep `awk 'BEGIN {print {{ tested_triggers }}*{{ tested_interval }}+{{ tested_interval }}-1}'`"
         on-success: disable_test_interval_timer
         on-failure: disable_test_interval_timer
     -


### PR DESCRIPTION
`bc` calculator is absent in `ubuntu/xenial64` vagrant.

```sh
ubuntu@ubuntu16:~$ st2 execution get 584361a7c898052882233732
id: 584361a7c898052882233732
status: failed (0s elapsed)
parameters: 
  cmd: sleep `echo 5*5+5-1 | bc`
  env:
    ST2_API_URL: http://127.0.0.1:9101
    ST2_AUTH_TOKEN: 57f10c711c5a409d8d8ba82a429ed266
    ST2_AUTH_URL: http://127.0.0.1:9100
    ST2_BASE_URL: http://127.0.0.1
result: 
  failed: true
  return_code: 1
  stderr: 'bash: bc: command not found

    sleep: missing operand

    Try ''sleep --help'' for more information.'
  stdout: ''
  succeeded: false
```

Use `awk` for calculation instead, which is already used in the end of workflow
[`name: check_trigger_intervals`](https://github.com/StackStorm/st2tests/blob/1add971e8e393db206951d08d75ee8f76dbbf4f6/packs/tests/actions/chains/test_timer_rule.yaml#L65).

