### PR TITLE
Mistral robot Test: Add delay in the all test cases

### DIFF
--- a/robotfm_tests/mistral/mistral_test_cancel.rst
+++ b/robotfm_tests/mistral/mistral_test_cancel.rst
@@ -16,19 +16,23 @@
          Log To Console       Execution ID: @{Execution ID}[-1]
 
      Get Execution Result
+         Sleep  2s
          ${result}=  Wait Until Keyword Succeeds  10s  1s  Execution Result
          Log To Console      \nGET EXECUTION: \n ${result.stdout}
 
      Cancel examples.mistral-test-cancel
+         Sleep  4s
          ${result}=  Wait Until Keyword Succeeds  10s  1s  Execution Cancel
          Log To Console       \nEXECUTION CANCEL: \n ${result.stdout}
 
      Check Canceled Execution
+         Sleep  4s
          ${Sleep}=   Evaluate  ${SLEEP}+10
          ${result}=  Wait Until Keyword Succeeds  ${Sleep}s  1s         Canceled Execution
          Log To Console       \nGET EXECUTION AFTER CANCELLATION:\n ${result.stdout}
 
      Executed successfully examples.mistral-test-cancel
+         Sleep  2s
          ${Sleep}=   Evaluate  ${SLEEP}+10
          ${result}=  Wait Until Keyword Succeeds  ${Sleep}s  1s  Final Execution
          Log To Console       \nGET EXECUTION AFTER COMPLETION: \n ${result.stdout}


### PR DESCRIPTION
Reason for intermediate failures: `Cancel examples.mistral-test-cancel` successfully executes after the `Run examples.mistral-test-cancel` and  `Get Execution Result`. However, `st2` doesn't get enough time to process the "cancel action" step and `Check Canceled Execution` test case fails (i.e the action doesn't get  cancelled and executes successfully): 

```
Run examples.mistral-test-cancel                                      
RUN EXECUTION: 
To get the results, execute:
 st2 execution get 583efd88d0c7d07d9086601f
Execution ID: 583efd88d0c7d07d9086601f
| PASS |
------------------------------------------------------------------------------
Get Execution Result                                                  
GET EXECUTION: 
{
    "action": {
        "ref": "examples.mistral-test-cancel"
    }, 
    "id": "583efd88d0c7d07d9086601f", 
    "parameters": {
        "sleep": 20
    }, 
    "start_timestamp": "2016-11-30T16:25:44.595453Z", 
    "status": "running"
}
[
    {
        "action": "core.local", 
        "id": "583efd8ad0c7d07d90866022", 
        "start_timestamp": "2016-11-30T16:25:46.293974Z", 
        "status": "running (1s elapsed)", 
        "task": "task1"
    }
]
| PASS |
------------------------------------------------------------------------------
Cancel examples.mistral-test-cancel                                   
EXECUTION CANCEL: 
action execution with id 583efd88d0c7d07d9086601f canceled.
| PASS |                                                   ###### Action should get cancelled after this step
------------------------------------------------------------------------------
Check Canceled Execution                                              | FAIL |
Keyword 'Canceled Execution' failed after retrying for 30 seconds. The last error was: '{
    "action": {
        "ref": "examples.mistral-test-cancel"
    }, 
    "end_timestamp": "2016-11-30T16:26:09.224980Z", 
    "id": "583efd88d0c7d07d9086601f", 
    "parameters": {
        "sleep": 20
    }, 
    "start_timestamp": "2016-11-30T16:25:44.595453Z", 
    "status": "succeeded"
}
[
    {
        "action": "core.local", 
        "id": "583efd8ad0c7d07d90866022", 
        "start_timestamp": "2016-11-30T16:25:46.293974Z", 
        "status": "succeeded (20s elapsed)",  ###### However it succeeds, because there is no delay in 
        "task": "task1"                                 ###### start and cancel action
    }, 
    {
        "action": "core.local", 
        "id": "583efd8ed0c7d07d90866024", 
        "start_timestamp": "2016-11-30T16:25:50.344577Z", 
        "status": "succeeded (20s elapsed)", 
        "task": "task1"
    }
]' contains '"status": "running' 0 times, not 1 time.
------------------------------------------------------------------------------
Executed successfully examples.mistral-test-cancel                    | FAIL |
Keyword 'Final Execution' failed after retrying for 30 seconds. The last error was: '{
    "action": {
        "ref": "examples.mistral-test-cancel"
    }, 
    "end_timestamp": "2016-11-30T16:26:09.224980Z", 
    "id": "583efd88d0c7d07d9086601f", 
    "parameters": {
        "sleep": 20
    }, 
    "start_timestamp": "2016-11-30T16:25:44.595453Z", 
    "status": "succeeded"
}
[
    {
        "action": "core.local", 
        "id": "583efd8ad0c7d07d90866022", 
        "start_timestamp": "2016-11-30T16:25:46.293974Z", 
        "status": "succeeded (20s elapsed)", 
        "task": "task1"
    }, 
    {
        "action": "core.local", 
        "id": "583efd8ed0c7d07d90866024", 
        "start_timestamp": "2016-11-30T16:25:50.344577Z", 
        "status": "succeeded (20s elapsed)", 
        "task": "task1"
    }
]' does not contain '"status": "canceled"'
------------------------------------------------------------------------------
```