### PR TITLE
Add more tests for pack install / packs.download

### DIFF
--- a/packs/tests/actions/chains/test_packs_pack.yaml
+++ b/packs/tests/actions/chains/test_packs_pack.yaml
@@ -4,6 +4,7 @@ vars:
         pack_to_install_1: "datadog"
         pack_to_install_2: "consul"
         pack_to_install_with_no_config: "freight"
+        pack_to_install_non_master_default_branch: "https://github.com/StackStorm-Exchange/stackstorm-test2.git"
         install_from_repo: "st2contrib"
         test_timeout: 180
 
@@ -149,7 +150,7 @@ chain:
               ST2_AUTH_TOKEN: "{{token}}"
             # triggers, sensors, actions, rules, aliases, policy types, policies, configs -> 9
             # 9 post pluggable runners
-            cmd: "st2 pack register"  # --fail-on-failure support needed. https://stackstorm.atlassian.net/browse/STORM-2456
+            cmd: "st2 pack register"
             timeout: "{{test_timeout}}"
         on-success: test_pack_install_with_no_config
         on-failure: error_handler
@@ -176,6 +177,20 @@ chain:
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
             cmd: "st2 pack install {{ pack_to_install_with_no_config }}"
+            timeout: "{{test_timeout}}"
+        on-success: test_pack_install_pack_with_non_master_default_branch
+        on-failure: error_handler
+    -
+        # Install a pack from Github which uses branch "aaa" and not master as a default branch
+        name: test_pack_install_pack_with_non_master_default_branch
+        ref: core.local
+        params:
+            env:
+              ST2_BASE_URL: "{{protocol}}://{{hostname}}"
+              ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
+              ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
+              ST2_AUTH_TOKEN: "{{token}}"
+            cmd: "st2 pack install {{ pack_to_install_non_master_default_branch }}"
             timeout: "{{test_timeout}}"
         on-success: success_handler
         on-failure: error_handler


### PR DESCRIPTION
This pull request adds a test case for installing a pack from git repository which uses a non-mater default branch.

It's a test case for bug fix in https://github.com/StackStorm/st2/pull/3201.