### PR TITLE
Fix broken core.http action check

### DIFF
--- a/packs/tests/actions/chains/test_quickstart_rules.yaml
+++ b/packs/tests/actions/chains/test_quickstart_rules.yaml
@@ -115,7 +115,7 @@ chain:
               ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 run core.http method=POST body='{\"you\": \"too\", \"name\": \"st2\"}' url={{protocol}}://{{hostname}}:9101/v1/webhooks/sample headers='x-auth-token={{token}};content-type=application/json' verify_ssl_cert=False"
+            cmd: "st2 run core.http method=POST body='{\"you\": \"too\", \"name\": \"st2\"}' url={{protocol}}://{{hostname}}:9101/v1/webhooks/sample headers='x-auth-token={{token}},content-type=application/json' verify_ssl_cert=False"
         on-success: test_check_output_after_post_via_st2
         on-failure: test_check_output_after_post_via_st2
     -


### PR DESCRIPTION
The code was using invalid notation for specifying multiple values - valid separator is `,` and not `;`.

As you can see, it resulted in headers being specified in correctly and as such, action failing:

```bash
| parameters      | {                                                            |
|                 |     "body": "{"you": "too", "name": "st2"}",                 |
|                 |     "url": "http://127.0.0.1:9101/v1/webhooks/sample",       |
|                 |     "method": "POST",                                        |
|                 |     "verify_ssl_cert": false,                                |
|                 |     "headers": {                                             |
|                 |         "x-auth-token": "792967ac8af147e7a9fbfd3021c1000a    |
|                 | ;content-type=application/json"                              |
|                 |     }                                                        |
|                 | }                                                            |
```

![screenshot from 2017-02-14 13-02-21](https://cloud.githubusercontent.com/assets/125088/22929661/122c33fa-f2bd-11e6-9814-528791dae386.png)


This should have never worked because it used invalid syntax, but it worked when running on non-st2enterprise installation because of the CLI auth.