### PR TITLE
Fix datastore access action test when RBAC is enabled

### DIFF
--- a/packs/fixtures/actions/pythonactions/datastore_test_action.py
+++ b/packs/fixtures/actions/pythonactions/datastore_test_action.py
@@ -1,3 +1,4 @@
+import os
 import json
 
 # This is to test imports within actions folder to check
@@ -46,6 +47,14 @@ class DatastoreTestAction(Action):
 
     def _test_datastore_actions_via_action_service(self):
         print('Test datastore access via action_service')
+
+        # Note: "decrypt" option requires admin access and when we generate service token that
+        # token isn't granted admin access so it won't work.
+        # To make the tests also pass on st2enteprise with RBAC we use explicit admin token
+        admin_token = os.environ.get('ST2_AUTH_TOKEN')
+        self.action_service.datastore_service._get_api_client()
+        os.environ['ST2_AUTH_TOKEN'] = admin_token
+
         data = {'somedata': 'foobar'}
         data_json_str = json.dumps(data)
 

--- a/packs/fixtures/actions/pythonactions/datastore_test_action.py
+++ b/packs/fixtures/actions/pythonactions/datastore_test_action.py
@@ -70,15 +70,15 @@ class DatastoreTestAction(Action):
 
         # decrypted value should match
         value = self.action_service.get_value('cache', decrypt=True)
-        if value != 'foo':
+        if not value or value != 'foo':
             raise Exception('Retrieved incorrect value from datastore: %s. Expected: %s' %
-                            (value.value, 'foo'))
+                            (value, 'foo'))
 
         # non-decrypted value should not match
         value = self.action_service.get_value('cache')
-        if value == 'foo':
+        if not value or value == 'foo':
             raise Exception('Retrieved incorrect value from datastore: %s. Did not expect: %s' %
-                            (value.value, 'foo'))
+                            (value, 'foo'))
 
         # Delete a value
         self.action_service.delete_value('cache')

--- a/packs/tests/actions/chains/test_quickstart_python_actions.yaml
+++ b/packs/tests/actions/chains/test_quickstart_python_actions.yaml
@@ -45,6 +45,8 @@ chain:
         value: 0
     on-success: "test_exception_python_action"
   -
+    # Verify that passing in an invalid parameter results in an exception and
+    # non zero exit code
     name: "test_exception_python_action"
     ref: "fixtures.streamwriter"
     params:
@@ -61,4 +63,9 @@ chain:
   -
     name: "test_datastore_access"
     ref: "fixtures.datastore_test_action"
-    params: {}
+    params:
+        env:
+            ST2_BASE_URL: "{{protocol}}://{{hostname}}"
+            ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
+            ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
+            ST2_AUTH_TOKEN: "{{token}}"


### PR DESCRIPTION
This pull request fixes the action in question so it also works and passes when RBAC is enabled.

The problem with action is that it relies on action_service token and token which is generated for action service use is intentionally not an admin token and as such ?decrypt option will throw access denied (it's intentionally not admin token otherwise every action could access all the values in plain text).

To make it work, I simply re-use admin token we-generate at the beginning of the tests and use that in the action service.