### PR TITLE
Add st2 login test

### DIFF
--- a/robotfm_tests/st2login_test.rst
+++ b/robotfm_tests/st2login_test.rst
@@ -1,10 +1,22 @@
-*** Test Cases ***
-Attempt to log in using "st2 login"
-    ${result}=         Run Process        st2 login st2admin --password Ch@ngeMe
-    Log To Console     \n${result.stdout}
-    Should Contain     ${result.stdout}   Successfully logged in as st2admin
+.. code:: robotframework
 
-Try running an action as the logged-in user
-    ${result}=         Run Process        st2 run core.local 
-    Log To Console     \n${result.stdout}
-    Should Contain     ${result.stdout}   succeeded: true
+    *** Settings ***
+    Library          Process
+    Library          String 
+    Library	     OperatingSystem 
+ 
+    *** Test Cases ***
+    Verify st2 is installed
+	${result}=         Run Process        st2  --version
+	Log To Console     \nOUTPUT: ${result.stdout}
+
+    Attempt to log in using "st2 login"
+	${result}=         Run Process        st2  login  st2admin  --password  Ch@ngeMe
+        Log To Console     \n${result.stdout}
+        Should Contain     ${result.stdout}   Logged in as st2admin
+
+    Try running an action as the logged-in user
+        ${result}=         Run Process        st2  run  core.local  date
+        Log To Console     \n${result.stdout}
+        Should Contain     ${result.stdout}   succeeded: true
+

--- a/robotfm_tests/st2login_test.rst
+++ b/robotfm_tests/st2login_test.rst
@@ -1,0 +1,10 @@
+*** Test Cases ***
+Attempt to log in using "st2 login"
+    ${result}=         Run Process        st2 login st2admin --password Ch@ngeMe
+    Log To Console     \n${result.stdout}
+    Should Contain     ${result.stdout}   Successfully logged in as st2admin
+
+Try running an action as the logged-in user
+    ${result}=         Run Process        st2 run core.local 
+    Log To Console     \n${result.stdout}
+    Should Contain     ${result.stdout}   succeeded: true

--- a/robotfm_tests/st2login_test.rst
+++ b/robotfm_tests/st2login_test.rst
@@ -7,11 +7,11 @@
  
     *** Test Cases ***
     Verify st2 is installed
-    ${result}=         Run Process        st2  --version
-    Log To Console     \nOUTPUT: ${result.stdout}
+        ${result}=         Run Process        st2  --version
+        Log To Console     \nOUTPUT: ${result.stdout}
 
     Attempt to log in using "st2 login"
-    ${result}=         Run Process        st2  login  st2admin  --password  Ch@ngeMe
+        ${result}=         Run Process        st2  login  st2admin  --password  Ch@ngeMe
         Log To Console     \n${result.stdout}
         Should Contain     ${result.stdout}   Logged in as st2admin
 

--- a/robotfm_tests/st2login_test.rst
+++ b/robotfm_tests/st2login_test.rst
@@ -3,7 +3,7 @@
     *** Settings ***
     Library          Process
     Library          String 
-    Library      OperatingSystem 
+    Library          OperatingSystem 
  
     *** Test Cases ***
     Verify st2 is installed

--- a/robotfm_tests/st2login_test.rst
+++ b/robotfm_tests/st2login_test.rst
@@ -3,15 +3,15 @@
     *** Settings ***
     Library          Process
     Library          String 
-    Library	     OperatingSystem 
+    Library      OperatingSystem 
  
     *** Test Cases ***
     Verify st2 is installed
-	${result}=         Run Process        st2  --version
-	Log To Console     \nOUTPUT: ${result.stdout}
+    ${result}=         Run Process        st2  --version
+    Log To Console     \nOUTPUT: ${result.stdout}
 
     Attempt to log in using "st2 login"
-	${result}=         Run Process        st2  login  st2admin  --password  Ch@ngeMe
+    ${result}=         Run Process        st2  login  st2admin  --password  Ch@ngeMe
         Log To Console     \n${result.stdout}
         Should Contain     ${result.stdout}   Logged in as st2admin
 


### PR DESCRIPTION
This adds a test case for `st2 login` command and subsequent commands using it's provided authentication configuration.

I have validated that this detects the current `st2 login` failure, and also that it succeeds when applying the fix in https://github.com/StackStorm/st2/pull/3226. See full output [here](
https://gist.github.com/Mierdin/97edc52116531f9c04d23a0e095e9a11)
