### PR TITLE
Fix the behavior of the mistral cancellation test

### DIFF
--- a/robotfm_tests/mistral/mistral_test_cancel.rst
+++ b/robotfm_tests/mistral/mistral_test_cancel.rst
@@ -4,6 +4,7 @@
      ${SLEEP}             20
      ${SUCCESS STATUS}    "status": "succeeded
      ${RUNNING STATUS}    "status": "running
+     ${CANCELING STATUS}  "status": "canceling"
      ${CANCELED STATUS}   "status": "canceled"
      ${FAILED STATUS}     "status": "failed"
 
@@ -40,7 +41,7 @@
     *** Keywords ***
     Execution Result
         ${result}=          Run Process  st2  execution  get  @{Execution ID}[-1]  -j
-        Should Contain X Times   ${result.stdout}  ${RUNNING STATUS}  2
+        Should Contain      ${result.stdout}  ${RUNNING STATUS}
         [return]            ${result}
 
     Execution Cancel
@@ -48,9 +49,15 @@
         Should Contain  ${result.stdout}   action execution with id @{Execution ID}[-1] canceled.
         [return]             ${result}
 
+    Canceling Execution
+         ${result}=           Run Process  st2  execution  get  @{Execution ID}[-1]      -j
+         Should Contain       ${result.stdout}  ${RUNNING STATUS}
+         Should Contain       ${result.stdout}  ${CANCELING STATUS}
+         [return]             ${result}
+
     Canceled Execution
          ${result}=           Run Process  st2  execution  get  @{Execution ID}[-1]      -j
-         Should Contain X Times   ${result.stdout}  ${RUNNING STATUS}  1
+         Should Contain       ${result.stdout}  ${SUCCESS STATUS}
          Should Contain       ${result.stdout}  ${CANCELED STATUS}
          [return]             ${result}
 


### PR DESCRIPTION
Mistral changed behavior to workflow cancellation. If there's a task that is still running, workflow will stay in canceling state instead of canceled state.

Here's the test run to show that the change passed.

```
(virtualenv) vagrant@arkham:~/projects/stackstorm/st2tests$ bash ./robot_parallel_tests.sh '--processes 1 robotfm_tests/mistral/' 0
Running Robot tests in parallel at: /home/vagrant/projects/stackstorm/st2tests

2017-08-12 00:30:06.375031 [PID:6390] [0] EXECUTING Mistral.Mistral Test Cancel
2017-08-12 00:30:21.456401 [PID:6390] [0] still running Mistral.Mistral Test Cancel after 15.0 seconds (next ping in 20.0 seconds)
2017-08-12 00:30:35.143946 [PID:6390] [0] PASSED Mistral.Mistral Test Cancel in 28.6 seconds
Output:  /home/vagrant/projects/stackstorm/st2tests/output.xml
Log:     /home/vagrant/projects/stackstorm/st2tests/log.html
Report:  /home/vagrant/projects/stackstorm/st2tests/report.html
Elapsed time: 0 minutes 29.21 seconds
#################################
Robot Tests Executed Successfully
#################################

Executing: Mistral.Mistral Test Cancel/
```