### PR TITLE
Add sleep to avoid race during trigger instance creation

### DIFF
--- a/packs/tests/actions/chains/test_key_triggers.yaml
+++ b/packs/tests/actions/chains/test_key_triggers.yaml
@@ -69,7 +69,7 @@ chain:
               ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 key set a b"
+            cmd: "st2 key set a b ; sleep 2"
         on-success: check_key_create_trigger_instance
     -
         name: check_key_create_trigger_instance
@@ -116,7 +116,7 @@ chain:
               ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 key set a c"
+            cmd: "st2 key set a c ; sleep 2"
         on-success: check_key_change_trigger_instance
     -
         name: check_key_change_trigger_instance


### PR DESCRIPTION
`st2 key set` causes trigger to be dispatched, but dispatch operation is aync this means that API returns and `set key set` operations can complete before trigger id dispatched an saved in the database.

That's the reason why those tests occasionally fail - we don't retrieve the correct key, because the trigger instance hasn't been written to the database yet.