### PR TITLE
Add a st2 CI conf file

### DIFF
--- a/conf/st2.ci.conf
+++ b/conf/st2.ci.conf
@@ -1,0 +1,78 @@
+# System-wide configuration
+
+[api]
+# Host and port to bind the API server.
+host = 127.0.0.1
+port = 9101
+logging = /etc/st2api/logging.conf
+mask_secrets = True
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[stream]
+logging = /etc/st2stream/logging.conf
+
+[sensorcontainer]
+logging = /etc/st2reactor/logging.sensorcontainer.conf
+
+[rulesengine]
+logging = /etc/st2reactor/logging.rulesengine.conf
+
+[actionrunner]
+logging = /etc/st2actions/logging.conf
+
+[auth]
+host = 127.0.0.1
+port = 9100
+use_ssl = False
+debug = False
+enable = True
+logging = /etc/st2auth/logging.conf
+
+mode = proxy
+
+# Note: Settings below are only used in "standalone" mode
+backend = flat_file
+backend_kwargs =
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url =
+
+[garbagecollector]
+logging = /etc/st2reactor/logging.garbagecollector.conf
+
+[system]
+base_path = /opt/stackstorm
+
+[syslog]
+host = 127.0.0.1
+port = 514
+facility = local7
+protocol = udp
+
+[webui]
+# webui_base_url = https://mywebhost.domain
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = True
+
+[system_user]
+user = stanley
+ssh_key_file = /home/stanley/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@127.0.0.1:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+
+[resultstracker]
+logging = /etc/st2actions/logging.resultstracker.conf
+
+[notifier]
+logging = /etc/st2actions/logging.notifier.conf
+
+[packs]
+enable_common_libs = True


### PR DESCRIPTION
We sometimes ship features with a config flag turned off by default but for testing we want to enable the config and test. The common libs feature is one such feature. It requires enable_common_libs to be set in config for testing. Otherwise, the CI would fail. 

I am including a CI st2 conf in st2tests for these purposes. Related https://github.com/StackStorm/st2cd/pull/319. 

I debated putting this in st2 repo conf/ folder but I did not like the fact that someone dealing with st2tests had to open a PR in st2. 