### PR TITLE
Ignore lines with status key

### DIFF
--- a/packs/tests/actions/chains/test_inquiry_mistral.yaml
+++ b/packs/tests/actions/chains/test_inquiry_mistral.yaml
@@ -177,7 +177,7 @@ chain:
 - name: "assert_workflow_succeeded_prep"
   ref: "core.local"
   params:
-    cmd: echo " { $(echo '{{ get_workflow_details_3.stdout }}' | grep succeeded | sed 's/,//g' | head -1) } "
+    cmd: echo " { $(echo '{{ get_workflow_details_3.stdout }}' | grep succeeded | grep -v status | sed 's/,//g' | head -1) } "
   on-success: "assert_workflow_succeeded"
 
 - name: "assert_workflow_succeeded"
@@ -201,7 +201,7 @@ chain:
   params:
     object: "{{ assert_workflow_expected_output_prep.stdout }}"
     key: stdout
-    value: We can now authenticate to foo service with bar
+    value: We can now authenticate to 'foo' service with bar
 
 - name: "fail"
   ref: core.local


### PR DESCRIPTION
Fix for failure of `test_inquiry_mistral` in `st2ci.st2_pkg_test_and_promote` workflow at noon on Aug 23, 2018.

Running `echo '{{ get_workflow_details_3.stdout }}' | grep succeeded...` results in the following output:

```
  "succeeded": true
  "status": "succeeded (16s elapsed)",
  "status": "succeeded (1s elapsed)",
```

Error in the failed e2e test indicates that one of the above status lines was erroneously used by `assert_workflow_succeeded`:

```
  ValueError: Objects not equal. Input: {u'status': u'succeeded (16s elapsed)'}, Expected: {u'succeeded': True}
```