### PR TITLE
Add tests for CLI include_attributes usage

### DIFF
--- a/robotfm_tests/cli/list_command_include_attributes.robot
+++ b/robotfm_tests/cli/list_command_include_attributes.robot
@@ -14,9 +14,9 @@ TEST:Verify include attributes works as expected for st2 execution list
     Should Not Contain   ${result}  end_timestamp
     Should Not Contain   ${result}  action.ref
 
-    ${result}=        Run  ${EXECUTION LIST} --attr doesntexist
-    Log To Console   \nRESULT:\n${result}
-    Should Contain   ${result}  Invalid or unsupported include attribute specified
+    ${result}=           Run  ${EXECUTION LIST} --attr doesntexist
+    Log To Console       \nRESULT:\n${result}
+    Should Contain       ${result}  Invalid or unsupported include attribute specified
 
 TEST:Verify include attributes works as expected for st2 action list
     ${result}=           Run  ${ACTION LIST} --attr name
@@ -25,9 +25,9 @@ TEST:Verify include attributes works as expected for st2 action list
     Should Not Contain   ${result}  pack
     Should Not Contain   ${result}  description
 
-    ${result}=        Run  ${ACTION LIST} --attr doesntexist
-    Log To Console   \nRESULT:\n${result}
-    Should Contain   ${result}  Invalid or unsupported include attribute specified
+    ${result}=           Run  ${ACTION LIST} --attr doesntexist
+    Log To Console       \nRESULT:\n${result}
+    Should Contain       ${result}  Invalid or unsupported include attribute specified
 
 
 *** Settings ***

--- a/robotfm_tests/cli/list_command_include_attributes.robot
+++ b/robotfm_tests/cli/list_command_include_attributes.robot
@@ -1,0 +1,36 @@
+*** Variables ***
+${EXECUTION LIST}         st2 execution list
+${ACTION LIST}            st2 action list
+
+
+*** Test Cases ***
+TEST:Verify include attributes works as expected for st2 execution list
+    ${result}=           Run  ${EXECUTION LIST} --attr id
+    Log To Console       \nRESULT:\n${result}
+    Should Contain       ${result}  id
+    Should Not Contain   ${result}  status
+    Should Not Contain   ${result}  context
+    Should Not Contain   ${result}  start_timestamp
+    Should Not Contain   ${result}  end_timestamp
+    Should Not Contain   ${result}  action.ref
+
+    ${result}=        Run  ${EXECUTION LIST} --attr doesntexist
+    Log To Console   \nRESULT:\n${result}
+    Should Contain   ${result}  Invalid or unsupported include attribute specified
+
+TEST:Verify include attributes works as expected for st2 action list
+    ${result}=           Run  ${ACTION LIST} --attr name
+    Log To Console       \nRESULT:\n${result}
+    Should Contain       ${result}  name
+    Should Not Contain   ${result}  pack
+    Should Not Contain   ${result}  description
+
+    ${result}=        Run  ${ACTION LIST} --attr doesntexist
+    Log To Console   \nRESULT:\n${result}
+    Should Contain   ${result}  Invalid or unsupported include attribute specified
+
+
+*** Settings ***
+Library            Process
+Library            OperatingSystem
+Resource           ../common/keywords.robot


### PR DESCRIPTION
Tests for CLI changes in https://github.com/StackStorm/st2/pull/4396.

It verifies that CLI correctly utilizes ``?include_attribute`` API query param filter.