### PR TITLE
Use shell=True when piping the output from one command to another

### DIFF
--- a/robotfm_tests/chatopsCI/chatops_self_check.robot
+++ b/robotfm_tests/chatopsCI/chatops_self_check.robot
@@ -6,7 +6,7 @@ TEST:Stackstorm client's connection
     # Run Keyword If   ${result.rc} != 0   Fatal Error    ST2 NOT RUNNING
 
 TEST:Hubot npm
-    ${result}=       Run Process    npm   list    \|  grep  hubot-stackstorm  cwd=/opt/stackstorm/chatops
+    ${result}=       Run Process    npm   list    \|  grep  hubot-stackstorm  shell=True  cwd=/opt/stackstorm/chatops
     Process Log To Console    ${result}
     Should Contain   ${result.stdout}  hubot-stackstorm@
     # Run Keyword If   ${result.rc} != 0   Fatal Error  HUBOT-STACKSTORM IS NOT INSTALLED


### PR DESCRIPTION
The error message `Unhandled rejection Error: Invalid tag name \"|\": Tags may not have any characters that encodeURIComponent encodes.` indicates that npm is being passed the pipe character as an argument (as well as "grep" and "hubot-stackstorm" as arguments), and npm then fails miserably at URI encoding the pipe character.

The [robotFM docs](http://robotframework.org/robotframework/2.8.6/libraries/Process.html#Specifying%20command%20and%20arguments) indicate that passing `shell=True` to the test will run the process in a shell, which should correctly interpret the pipe character as a pipe operator (instead of an argument) and run `grep` as expected.

See this for more: https://groups.google.com/forum/#!topic/robotframework-users/Mhy0yOUdrEU