### PR TITLE
config_context renders against incorrect pack

### DIFF
--- a/packs/tests/actions/render_config_context.py
+++ b/packs/tests/actions/render_config_context.py
@@ -1,0 +1,7 @@
+from st2common.runners.base_action import Action
+
+
+class PrintPythonVersionAction(Action):
+
+    def run(self, value1):
+        return {"context_value": value1}

--- a/packs/tests/actions/render_config_context.yaml
+++ b/packs/tests/actions/render_config_context.yaml
@@ -1,0 +1,12 @@
+---
+name: render_config_context
+runner_type: python-script
+description: Action that uses config context
+enabled: true
+entry_point: render_config_context.py
+parameters:
+  value1:
+    description: Input for render_config_context. Defaults to config_context value.
+    required: false
+    type: "string"
+    default: "{{ config_context.config_item_one }}"

--- a/packs/tests/config.schema.yaml
+++ b/packs/tests/config.schema.yaml
@@ -1,0 +1,6 @@
+---
+config_item_one:
+  description: "Item use to test config context."
+  type: "string"
+  required: true
+  default: "Testing"


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2/issues/4567 : config_context renders against incorrect pack

Add new action to `tests` pack for render config context integration test.
This is second part of code changes. Please see https://github.com/StackStorm/st2/pull/4570 