### PR TITLE
Add "st2 execution tail" end to end tests for Orquesta workflows

### DIFF
--- a/cli/test_execution_tail.bats
+++ b/cli/test_execution_tail.bats
@@ -61,7 +61,7 @@ teardown() {
 @test "st2 execution tail command works correctly for Mistral workflows" {
 	run ls /opt/stackstorm/mistral/
 	if [[ "$status" -ne 0 ]]; then
-		skip "Mistral no available, skipping tests"
+		skip "Mistral not available, skipping tests"
 	fi
 
 	run eval "st2 run examples.mistral-streaming-demo count=5 sleep_delay=1 -a | grep 'st2 execution tail' | sed 's/ st2 execution tail//'"

--- a/cli/test_execution_tail.bats
+++ b/cli/test_execution_tail.bats
@@ -78,3 +78,24 @@ teardown() {
 	assert_output --regexp "Child execution \\(task=task10\\) [0-9a-f]{24} has finished \\(status=succeeded\\)\."
 	assert_output --regexp "Execution [0-9a-f]{24} has completed \\(status=succeeded\\)."
 }
+
+@test "st2 execution tail command works correctly for Orquesta workflows" {
+    run st2 runner get orquesta > /dev/null/
+	if [[ "$status" -ne 0 ]]; then
+		skip "Orquesta not available, skipping tests"
+	fi
+
+	run eval "st2 run examples.orquesta-streaming-demo count=5 sleep_delay=1 -a | grep 'st2 execution tail' | sed 's/ st2 execution tail//'"
+	assert_success
+	EXECUTION_ID="$output"
+
+	# Run the execution tail command - this may take awhile
+	run eval "st2 execution tail $EXECUTION_ID"
+	assert_success
+
+	assert_output --regexp "Child execution \\(task=task3\\) [0-9a-f]{24} has started\..*"
+	assert_output --regexp "Child execution \\(task=task3\\) [0-9a-f]{24} has finished \\(status=succeeded\\)\."
+	assert_output --regexp "Child execution \\(task=task10\\) [0-9a-f]{24} has started\..*"
+	assert_output --regexp "Child execution \\(task=task10\\) [0-9a-f]{24} has finished \\(status=succeeded\\)\."
+	assert_output --regexp "Execution [0-9a-f]{24} has completed \\(status=succeeded\\)."
+}

--- a/cli/test_execution_tail.bats
+++ b/cli/test_execution_tail.bats
@@ -59,7 +59,7 @@ teardown() {
 }
 
 @test "st2 execution tail command works correctly for Mistral workflows" {
-	run ls /opt/stackstorm/mistral/
+	run st2 runner get mistral-v2 > /dev/null/
 	if [[ "$status" -ne 0 ]]; then
 		skip "Mistral not available, skipping tests"
 	fi
@@ -80,7 +80,7 @@ teardown() {
 }
 
 @test "st2 execution tail command works correctly for Orquesta workflows" {
-    run st2 runner get orquesta > /dev/null/
+	run st2 runner get orquesta > /dev/null/
 	if [[ "$status" -ne 0 ]]; then
 		skip "Orquesta not available, skipping tests"
 	fi


### PR DESCRIPTION
This pull request adds missing end to end test for ``st2 execution tail`` CLI command for Orquesta workflows.

It requires changes (action) from here - https://github.com/StackStorm/st2/pull/4638.