### PR TITLE
Add a common utility function which makes debugging test failures

### DIFF
--- a/cli/test_pack_python3.bats
+++ b/cli/test_pack_python3.bats
@@ -1,5 +1,6 @@
 load '../test_helpers/bats-support/load'
 load '../test_helpers/bats-assert/load'
+load '../test_helpers/common'
 
 setup() {
 	if [[ ! -d /opt/stackstorm/packs/examples ]]; then
@@ -42,7 +43,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 @test "packs.setup_virtualenv without python3 flags works and defaults to Python 2" {
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
-	SETUP_VENV_RESULTS=$(st2 run packs.setup_virtualenv packs=examples -j)
+	SETUP_VENV_RESULTS=$(run_command_and_log_output st2 run packs.setup_virtualenv packs=examples -j)
 	run eval "echo '$SETUP_VENV_RESULTS' | jq -r '.result.result'"
 	assert_success
 
@@ -52,9 +53,6 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 	assert_success
 
 	assert_output "succeeded"
-
-	run st2-register-content --register-pack /opt/stackstorm/packs/examples/ --register-all
-	assert_success
 
 	run /opt/stackstorm/virtualenvs/examples/bin/python --version
 	assert_output --partial "Python 2.7"
@@ -66,7 +64,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 @test "packs.setup_virtualenv with python3 flag works" {
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
-	SETUP_VENV_RESULTS=$(st2 run packs.setup_virtualenv packs=examples python3=true -j)
+	SETUP_VENV_RESULTS=$(run_command_and_log_output st2 run packs.setup_virtualenv packs=examples python3=true -j)
 	run eval "echo '$SETUP_VENV_RESULTS' | jq -r '.result.result'"
 	assert_success
 
@@ -81,7 +79,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 
 	assert_output --partial "Python 3."
 
-	RESULT=$(st2 run examples.python_runner_print_python_version -j)
+	RESULT=$(run_command_and_log_output st2 run examples.python_runner_print_python_version -j)
 	assert_success
 
 	run eval "echo '$RESULT' | jq -r '.result.stdout'"
@@ -108,7 +106,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 	run st2 pack install python3_test --python3 -j
 	assert_success
 
-	RESULT=$(st2 run python3_test.test_stdlib_import -j)
+	RESULT=$(run_command_and_log_output st2 run python3_test.test_stdlib_import -j)
 	assert_success
 
 	run eval "echo '$RESULT' | jq -r '.result.result'"

--- a/test_helpers/common.sh
+++ b/test_helpers/common.sh
@@ -1,0 +1,42 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common bash utility functions used by test code
+
+run_command_and_log_output() {
+    # Utility function which runs a bash command and logs the command output (stdout) and exit
+    # code.
+    #
+    # This comes handy in scenarios where you want to save command stdout in a variable, but you
+    # also want to output the command stdout to make troubleshooting / debugging n test failures
+    # easier.
+    #
+    # Example usage:
+    #
+    # RESULT=$(run_command_and_log_output st2 run pack install packs=examples)
+    #
+    # 1. Run the command and capture the outputs
+    eval "$({ stderr=$({ stdout=$($@); exit_code=$?; } 2>&1; declare -p stdout exit_code >&2); declare -p stderr ; } 2>&1)"
+
+    # 2. Log the output to stderr
+    >&2 echo "=========="
+    >&2 echo "Ran command: ${@}"
+    >&2 echo "Stdout: ${stdout}"
+    >&2 echo "stderr: ${stderr}"
+    >&2 echo "Exit code: ${exit_code}"
+    >&2 echo "=========="
+
+    # 3. Return original command value
+    echo ${stdout}
+}


### PR DESCRIPTION
This pull request establishes a better pattern for handling tests where we need to store shell command output in a variable before processing it / asserting on it.

Without this change it's very hard / impossible to debug test failures which are result of a shell command which output is stored to a variable. Only way to debug those would be to re-run the tests and add additional log / print statements or similar (and in a lot of scenarios that's very slow and expensive and means waiting 30 minutes or more).

This pull request adds a new helper function which prints command output (stdout, stderr, return code / exit code) to stderr. This is a similar pattern to the one we had in robot and makes debugging much easier and faster since you immediately have access to command output on failure.

Before:

```bash
 ✗ packs.setup_virtualenv without python3 flags works and defaults to Python 2
   (in test file cli/test_pack_python3.bats, line 38)
     `SETUP_VENV_RESULTS=$(st2 run packs.setup_virtualenv packs=examples -j)' failed

1 test, 1 failure
```

Tests failed. Why? Who knows. No way to know without having access to that command output and at the very least this means re-running tests which is a huge waste of time.

With this change:

```bash
 ✗ packs.setup_virtualenv without python3 flags works and defaults to Python 2
   (from function `assert_output' in file cli/../test_helpers/bats-assert/src/assert.bash, line 239,
    in test file cli/test_pack_python3.bats, line 27)
     `assert_output "Successfully set up virtualenv for the following packs: examples"' failed
     null
   ==========
   Ran command: st2 run packs.setup_virtualenv packs=examples -j
   Stdout: 
   {
       "id": "5cdc705afb071a348b9cac3a", 
       "parameters": {
           "packs": [
               "examples"
           ]
       }, 
       "result": {
           "exit_code": 1, 
           "result": "None", 
           "stderr": "st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Setting up virtualenv for pack \"examples\" (None)\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/python_runner/python_action_wrapper.py\", line 333, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/python_runner/python_action_wrapper.py\", line 192, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/packs/actions/pack_mgmt/setup_virtualenv.py\", line 88, in run\n    no_download=no_download)\n  File \"/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/util/virtualenvs.py\", line 86, in setup_pack_virtualenv\n    raise Exception(msg)\nException: Pack \"examples\" is not installed. Looked in: /opt/stackstorm/packs\n", 
           "stdout": ""
       }, 
       "status": "failed"
   }
   stderr: 
   Exit code: 1
   ==========

```


Resolves #160.