### PR TITLE
Speed up datastore expiry tests for 60 seconds

### DIFF
--- a/docs/test_key_triggers.bats
+++ b/docs/test_key_triggers.bats
@@ -249,7 +249,8 @@ KEY_JSON_FILE="docs/test_key_triggers.json"
 	# work, item could still be visible for a while after expire has already passed
 	# "TTL Monitor is a separate thread that runs periodically (usually every
 	# minute) and scans a collection"
-	sleep 65
+	# See https://github.com/StackStorm/st2cd/pull/397
+	sleep 3
 
 	# Get a list of all keys
 	KEY_LIST_RESULTS=$(st2 key list -j)

--- a/docs/test_key_triggers.bats
+++ b/docs/test_key_triggers.bats
@@ -250,7 +250,7 @@ KEY_JSON_FILE="docs/test_key_triggers.json"
 	# "TTL Monitor is a separate thread that runs periodically (usually every
 	# minute) and scans a collection"
 	# See https://github.com/StackStorm/st2cd/pull/397
-	sleep 3
+	sleep 2
 
 	# Get a list of all keys
 	KEY_LIST_RESULTS=$(st2 key list -j)


### PR DESCRIPTION
Needs this change - https://github.com/StackStorm/st2cd/pull/397.