### PR TITLE
Add check to skip py3 cli tests if st2 is v3 or below

### DIFF
--- a/cli/test_pack_python3.bats
+++ b/cli/test_pack_python3.bats
@@ -13,7 +13,7 @@ skip_tests_if_st2_le_v3() {
     ST2_VER=$(echo ${ST2_VER//.})
 
     if [[ "${ST2_VER}" -le "300" ]]; then
-        skip "StackStorm is v3.0.0 or below"
+        skip "Python 3 imports are broken on StackStorm < 3.0.1, skipping tests"
     fi
 }
 

--- a/cli/test_pack_python3.bats
+++ b/cli/test_pack_python3.bats
@@ -32,6 +32,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 }
 
 @test "SETUP: Install and register examples pack" {
+	skip_tests_if_st2_le_v3
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
 	if [[ ! -d /opt/stackstorm/packs/examples ]]; then
@@ -48,6 +49,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 }
 
 @test "packs.setup_virtualenv without python3 flags works and defaults to Python 2" {
+	skip_tests_if_st2_le_v3
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
 	SETUP_VENV_RESULTS=$(st2 run packs.setup_virtualenv packs=examples -j)
@@ -65,6 +67,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 }
 
 @test "packs.setup_virtualenv with python3 flag works" {
+	skip_tests_if_st2_le_v3
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
 	SETUP_VENV_RESULTS=$(st2 run packs.setup_virtualenv packs=examples python3=true -j)
@@ -104,6 +107,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 }
 
 @test "python3 imports work correctly" {
+	skip_tests_if_st2_le_v3
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
 	run st2 pack install python3_test --python3 -j
@@ -116,6 +120,7 @@ skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 }
 
 @test "TEARDOWN: Uninstall examples and python3_test pack" {
+	skip_tests_if_st2_le_v3
 	skip_tests_if_python3_is_not_available_or_if_already_running_under_python3
 
 	if [[ -d /opt/stackstorm/packs/examples ]]; then

--- a/cli/test_pack_python3.bats
+++ b/cli/test_pack_python3.bats
@@ -1,6 +1,22 @@
 load '../test_helpers/bats-support/load'
 load '../test_helpers/bats-assert/load'
 
+skip_tests_if_st2_le_v3() {
+    # Utility function which skips tests if st2 is v3.0.0 or below. The py3 tests
+    # here require the fix https://github.com/StackStorm/st2/pull/4674 that will
+    # not be released until v3.0.1.
+
+    ST2_VER=$(st2 --version 2>&1)
+    ST2_VER=$(echo ${ST2_VER} | cut -d',' -f1)
+    ST2_VER=$(echo ${ST2_VER} | cut -d' ' -f2)
+    ST2_VER=$(echo ${ST2_VER} | sed -e "s/dev/.0/g")
+    ST2_VER=$(echo ${ST2_VER//.})
+
+    if [[ "${ST2_VER}" -le "300" ]]; then
+        skip "StackStorm is v3.0.0 or below"
+    fi
+}
+
 skip_tests_if_python3_is_not_available_or_if_already_running_under_python3() {
 	# Utility function which skips tests if python3 binary is not available on the system or if
 	# StackStorm components are already running under Python 3 (e.g. Ubuntu Xenial)


### PR DESCRIPTION
Add check to skip py3 cli tests if st2 is v3 or below because a required fix for py3 tests to pass is released in v3.0.1.