### PR TITLE
End to end test cases for `st2chatops` bad ST2 config.

### DIFF
--- a/chatops/test-hubot-st2-badconfig.bats
+++ b/chatops/test-hubot-st2-badconfig.bats
@@ -1,0 +1,105 @@
+
+load '../test_helpers/bats-support/load'
+load '../test_helpers/bats-assert/load'
+
+
+ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
+
+@test "SETUP: setup environment variables for authentication related variables." {
+	`sed -e '/ ST2_API_KEY=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_TOKEN= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_USERNAME= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_PASSWORD= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_URL= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`;
+}
+
+@test "exit with error status from unresolved ST2_API_URL." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_API_URL=http://non-existent:9101/ bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "Failed to retrieve commands from "$ST2_API_URL""
+}
+
+@test "exit with error status from only providing user name for authentication." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_AUTH_USERNAME="st2admin" bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
+	                        "and ST2_AUTH_URL should only be used together"
+}
+
+@test "exit with error status from only providing user password for authentication." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_AUTH_PASSWORD="testp" bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
+	                        "and ST2_AUTH_URL should only be used together"
+}
+
+@test "exit with error status from only providing user name and password for authentication." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
+	                        "and ST2_AUTH_URL should only be used together"
+}
+
+@test "exit with error status from unresolved ST2_AUTH_URL." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" " \
+	                               "ST2_AUTH_URL=http://non-existent:9100/ bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "Failed to authenticate: getaddrinfo EAI_AGAIN non-existent"
+}
+
+@test "exit with error status from invalid ST2_AUTH_TOKEN." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_AUTH_TOKEN=invalidst2authtoken bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "Failed to retrieve commands from"
+	assert_output --partial "Unauthorized"
+}
+
+@test "exit with error status from invalid ST2_API_KEY." {
+	run eval "("\
+	         " cd /opt/stackstorm/chatops; "\
+	         " ST2_API_KEY=invalidst2apikey bin/hubot --test; "\
+	         ")"
+
+	assert_failure
+	assert_equal $status 1
+	assert_output --partial "ERROR Failed to retrieve commands from"
+	assert_output --partial "Unauthorized - ApiKey"
+}
+
+@test "TEARDOWN: remove environment variables changes for authentication related variables." {
+	`sed -i '/^#.* ST2_API_KEY=/s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_TOKEN= /s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_USERNAME= /s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_PASSWORD= /s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_URL= /s/^#//' $ST2_CHATOPS_ENV_FILE`
+}

--- a/chatops/test-hubot-st2-badconfig.bats
+++ b/chatops/test-hubot-st2-badconfig.bats
@@ -4,20 +4,18 @@ load '../test_helpers/bats-assert/load'
 
 
 ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
+cd /opt/stackstorm/chatops
 
 @test "SETUP: setup environment variables for authentication related variables." {
 	`sed -e '/ ST2_API_KEY=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 	`sed -e '/ ST2_AUTH_TOKEN= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 	`sed -e '/ ST2_AUTH_USERNAME= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 	`sed -e '/ ST2_AUTH_PASSWORD= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
-	`sed -e '/ ST2_AUTH_URL= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`;
+	`sed -e '/ ST2_AUTH_URL= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 }
 
 @test "exit with error status from unresolved ST2_API_URL." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_API_URL=http://non-existent:9101/ bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_API_URL=http://non-existent:9101/ bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1
@@ -25,10 +23,7 @@ ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 }
 
 @test "exit with error status from only providing user name for authentication." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_AUTH_USERNAME="st2admin" bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_AUTH_USERNAME="st2admin" bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1
@@ -37,10 +32,7 @@ ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 }
 
 @test "exit with error status from only providing user password for authentication." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_AUTH_PASSWORD="testp" bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_AUTH_PASSWORD="testp" bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1
@@ -49,10 +41,7 @@ ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 }
 
 @test "exit with error status from only providing user name and password for authentication." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1
@@ -61,11 +50,8 @@ ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 }
 
 @test "exit with error status from unresolved ST2_AUTH_URL." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" " \
-	                               "ST2_AUTH_URL=http://non-existent:9100/ bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" "\
+	          "ST2_AUTH_URL=http://non-existent:9100/ bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1
@@ -73,10 +59,7 @@ ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 }
 
 @test "exit with error status from invalid ST2_AUTH_TOKEN." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_AUTH_TOKEN=invalidst2authtoken bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_AUTH_TOKEN=invalidst2authtoken bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1
@@ -85,10 +68,7 @@ ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 }
 
 @test "exit with error status from invalid ST2_API_KEY." {
-	run eval "("\
-	         " cd /opt/stackstorm/chatops; "\
-	         " ST2_API_KEY=invalidst2apikey bin/hubot --test; "\
-	         ")"
+	run eval "(ST2_API_KEY=invalidst2apikey bin/hubot --test)"
 
 	assert_failure
 	assert_equal $status 1

--- a/chatops/test-hubot-st2-badconfig.bats
+++ b/chatops/test-hubot-st2-badconfig.bats
@@ -6,7 +6,7 @@ load '../test_helpers/bats-assert/load'
 ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 cd /opt/stackstorm/chatops
 
-@test "SETUP: setup environment variables for authentication related variables." {
+@test "SETUP: make sure ENV variables are unset in st2chatops.env to test edge cases" {
 	`sed -e '/ ST2_API_KEY=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 	`sed -e '/ ST2_AUTH_TOKEN= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 	`sed -e '/ ST2_AUTH_USERNAME= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
@@ -17,16 +17,14 @@ cd /opt/stackstorm/chatops
 @test "exit with error status from unresolved ST2_API_URL." {
 	run eval "(ST2_API_URL=http://non-existent:9101/ bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "Failed to retrieve commands from "$ST2_API_URL""
 }
 
 @test "exit with error status from only providing user name for authentication." {
 	run eval "(ST2_AUTH_USERNAME="st2admin" bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
 	                        "and ST2_AUTH_URL should only be used together"
 }
@@ -34,8 +32,7 @@ cd /opt/stackstorm/chatops
 @test "exit with error status from only providing user password for authentication." {
 	run eval "(ST2_AUTH_PASSWORD="testp" bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
 	                        "and ST2_AUTH_URL should only be used together"
 }
@@ -43,8 +40,7 @@ cd /opt/stackstorm/chatops
 @test "exit with error status from only providing user name and password for authentication." {
 	run eval "(ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
 	                        "and ST2_AUTH_URL should only be used together"
 }
@@ -53,16 +49,14 @@ cd /opt/stackstorm/chatops
 	run eval "(ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" "\
 	          "ST2_AUTH_URL=http://non-existent:9100/ bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "Failed to authenticate: getaddrinfo EAI_AGAIN non-existent"
 }
 
 @test "exit with error status from invalid ST2_AUTH_TOKEN." {
 	run eval "(ST2_AUTH_TOKEN=invalidst2authtoken bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "Failed to retrieve commands from"
 	assert_output --partial "Unauthorized"
 }
@@ -70,13 +64,12 @@ cd /opt/stackstorm/chatops
 @test "exit with error status from invalid ST2_API_KEY." {
 	run eval "(ST2_API_KEY=invalidst2apikey bin/hubot --test)"
 
-	assert_failure
-	assert_equal $status 1
+	assert_failure 1
 	assert_output --partial "ERROR Failed to retrieve commands from"
 	assert_output --partial "Unauthorized - ApiKey"
 }
 
-@test "TEARDOWN: remove environment variables changes for authentication related variables." {
+@test "TEARDOWN: revert changes for ENV variables in st2chatops.env for test cases." {
 	`sed -i '/^#.* ST2_API_KEY=/s/^#//' $ST2_CHATOPS_ENV_FILE`
 	`sed -i '/^#.* ST2_AUTH_TOKEN= /s/^#//' $ST2_CHATOPS_ENV_FILE`
 	`sed -i '/^#.* ST2_AUTH_USERNAME= /s/^#//' $ST2_CHATOPS_ENV_FILE`

--- a/chatops/test-hubot-st2-badconfig.bats
+++ b/chatops/test-hubot-st2-badconfig.bats
@@ -6,73 +6,91 @@ load '../test_helpers/bats-assert/load'
 ST2_CHATOPS_ENV_FILE='/opt/stackstorm/chatops/st2chatops.env'
 cd /opt/stackstorm/chatops
 
-@test "SETUP: make sure ENV variables are unset in st2chatops.env to test edge cases" {
-	`sed -e '/ ST2_API_KEY=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
-	`sed -e '/ ST2_AUTH_TOKEN= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
-	`sed -e '/ ST2_AUTH_USERNAME= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
-	`sed -e '/ ST2_AUTH_PASSWORD= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
-	`sed -e '/ ST2_AUTH_URL= /s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
-}
 
 @test "exit with error status from unresolved ST2_API_URL." {
-	run eval "(ST2_API_URL=http://non-existent:9101/ bin/hubot --test)"
+	export ST2_API_URL=http://non-existent:9101/
 
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "Failed to retrieve commands from "$ST2_API_URL""
+	assert_output --partial "Failed to retrieve commands from $ST2_API_URL"
+}
+
+@test "exit with error status from unresolved ST2_STREAM_URL." {
+	export ST2_STREAM_URL=http://non-existent:9101/
+
+	run bin/hubot --test
+	assert_failure 1
+	assert_output --partial "stream error"
+}
+
+@test "SETUP: make sure ENV variables are unset in st2chatops.env to test edge cases" {
+	`sed -e '/ ST2_API_KEY=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_TOKEN=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_USERNAME=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_PASSWORD=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
+	`sed -e '/ ST2_AUTH_URL=/s/^/#/g' -i $ST2_CHATOPS_ENV_FILE`
 }
 
 @test "exit with error status from only providing user name for authentication." {
-	run eval "(ST2_AUTH_USERNAME="st2admin" bin/hubot --test)"
-
+	export ST2_AUTH_USERNAME=st2admin
+	
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
+	assert_output --partial "Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
 	                        "and ST2_AUTH_URL should only be used together"
 }
 
 @test "exit with error status from only providing user password for authentication." {
-	run eval "(ST2_AUTH_PASSWORD="testp" bin/hubot --test)"
+	export ST2_AUTH_PASSWORD=testp
 
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
+	assert_output --partial "Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
 	                        "and ST2_AUTH_URL should only be used together"
 }
 
 @test "exit with error status from only providing user name and password for authentication." {
-	run eval "(ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" bin/hubot --test)"
+	export ST2_AUTH_USERNAME=st2admin
+	export ST2_AUTH_PASSWORD=testp
 
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "Error: Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
+	assert_output --partial "Env variables ST2_AUTH_USERNAME, ST2_AUTH_PASSWORD " \
 	                        "and ST2_AUTH_URL should only be used together"
 }
 
 @test "exit with error status from unresolved ST2_AUTH_URL." {
-	run eval "(ST2_AUTH_USERNAME="st2admin" ST2_AUTH_PASSWORD="testp" "\
-	          "ST2_AUTH_URL=http://non-existent:9100/ bin/hubot --test)"
+	export ST2_AUTH_USERNAME=st2admin
+	export ST2_AUTH_PASSWORD="testp"
+	export ST2_AUTH_URL="http://non-existent:9100/"
 
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "Failed to authenticate: getaddrinfo EAI_AGAIN non-existent"
+	assert_output --partial "Failed to authenticate"
 }
 
 @test "exit with error status from invalid ST2_AUTH_TOKEN." {
-	run eval "(ST2_AUTH_TOKEN=invalidst2authtoken bin/hubot --test)"
+	export ST2_AUTH_TOKEN=invalidst2authtoken
 
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "Failed to retrieve commands from"
+	assert_output --partial "Failed to retrieve commands"
 	assert_output --partial "Unauthorized"
 }
 
 @test "exit with error status from invalid ST2_API_KEY." {
-	run eval "(ST2_API_KEY=invalidst2apikey bin/hubot --test)"
+	export ST2_API_KEY=invalidst2apikey
 
+	run bin/hubot --test
 	assert_failure 1
-	assert_output --partial "ERROR Failed to retrieve commands from"
+	assert_output --partial "Failed to retrieve commands"
 	assert_output --partial "Unauthorized - ApiKey"
 }
 
 @test "TEARDOWN: revert changes for ENV variables in st2chatops.env for test cases." {
 	`sed -i '/^#.* ST2_API_KEY=/s/^#//' $ST2_CHATOPS_ENV_FILE`
-	`sed -i '/^#.* ST2_AUTH_TOKEN= /s/^#//' $ST2_CHATOPS_ENV_FILE`
-	`sed -i '/^#.* ST2_AUTH_USERNAME= /s/^#//' $ST2_CHATOPS_ENV_FILE`
-	`sed -i '/^#.* ST2_AUTH_PASSWORD= /s/^#//' $ST2_CHATOPS_ENV_FILE`
-	`sed -i '/^#.* ST2_AUTH_URL= /s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_TOKEN=/s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_USERNAME=/s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_PASSWORD=/s/^#//' $ST2_CHATOPS_ENV_FILE`
+	`sed -i '/^#.* ST2_AUTH_URL=/s/^#//' $ST2_CHATOPS_ENV_FILE`
 }


### PR DESCRIPTION
Fixes https://github.com/StackStorm/st2chatops/issues/124
End to end test cases for `st2chatops` invalid ST2 authentication and API URL.
During st2chatops starts up, st2chatops.env is source’d directly and overwrites environment variable value passed from command line unless the it is not enabled.
In order to test different authentication configurations, disable all authentication related variables before test (SETUP) and revert changes after test (TEARDOWN)