### PR TITLE
Check installed pack version as expected

### DIFF
--- a/packs/tests/actions/chains/test_run_pack_tests_tool.yaml
+++ b/packs/tests/actions/chains/test_run_pack_tests_tool.yaml
@@ -3,7 +3,7 @@ vars:
     base_repo_url: "https://github.com/StackStorm"
     # Note: Pack 1 should have no external dependencies beyond Python stdlib ones.
     pack_to_install_1: "csv"
-    pack_to_install_2: "xml"
+    pack_to_install_2: "xml=0.3.0"
     test_timeout: 180
 
 chain:
@@ -18,8 +18,17 @@ chain:
               ST2_AUTH_TOKEN: "{{token}}"
             cmd: "st2 pack install {{ pack_to_install_1 }}"
             timeout: "{{test_timeout}}"
+        on-success: test_installed_pack_1_version
+        on-failure: error_handler
+
+    -
+        name: test_installed_pack_1_version
+        ref: tests.test_installed_pack_version
+        params:
+            installed_pack: "{{ pack_to_install_1 }}"
         on-success: install_pack_2
         on-failure: error_handler
+
     -
         name: install_pack_2
         ref: core.local
@@ -31,8 +40,17 @@ chain:
               ST2_AUTH_TOKEN: "{{token}}"
             cmd: "st2 pack install {{ pack_to_install_2 }}"
             timeout: "{{test_timeout}}"
+        on-success: test_installed_pack_2_version
+        on-failure: error_handler
+
+    -
+        name: test_installed_pack_2_version
+        ref: tests.test_installed_pack_version
+        params:
+            installed_pack: "{{ pack_to_install_2 }}"
         on-success: run_pack_tests_without_creating_virtualenv
         on-failure: error_handler
+
     -
         name: run_pack_tests_without_creating_virtualenv
         ref: core.local

--- a/packs/tests/actions/test_installed_pack_version.py
+++ b/packs/tests/actions/test_installed_pack_version.py
@@ -1,0 +1,55 @@
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from st2common.constants.pack import PACK_VERSION_SEPARATOR
+from st2common.runners.base_action import Action
+from st2common.util.pack import get_pack_metadata
+from st2common.util.pack_management import get_repo_url
+
+
+class TesetInstalledPackVersionAction(Action):
+    def run(self, installed_pack):
+        """
+        :param installed_pack: Installed pack name with version
+        :type: installed_pack: ``string``
+        """
+
+        if not installed_pack:
+            return False, False
+
+        pack_and_version = installed_pack.split(PACK_VERSION_SEPARATOR)
+        pack_name = pack_and_version[0]
+        pack_version = pack_and_version[1] if len(pack_and_version) > 1 else None
+
+        # Pack version is not specified. Get pack version from index.json file.
+        if not pack_version:
+            try:
+                _, pack_version = get_repo_url(pack_name, proxy_config=None)
+            except Exception:
+                print ('No record of the "%s" pack in the index.' % (pack_name))
+                return False, False
+
+        # Get installed pack version from local pack metadata file.
+        try:
+            pack_dir = '/opt/stackstorm/packs/%s/' % (pack_name)
+            pack_metadata = get_pack_metadata(pack_dir=pack_dir)
+            local_pack_version = pack_metadata.get('version', None)
+        except Exception:
+            print ('Could not open pack.yaml file at location %s' % (pack_dir))
+            return False, False
+
+        if pack_version == local_pack_version:
+            return True, True
+        else:
+            return False, False

--- a/packs/tests/actions/test_installed_pack_version.yaml
+++ b/packs/tests/actions/test_installed_pack_version.yaml
@@ -1,0 +1,12 @@
+---
+name: "test_installed_pack_version"
+runner_type: "python-script"
+description: "Test installed pack version."
+pack: tests
+enabled: true
+entry_point: "test_installed_pack_version.py"
+parameters:
+  installed_pack:
+    type: "string"
+    description: "Name of pack to check"
+    required: true


### PR DESCRIPTION
Part of Fixed: https://github.com/StackStorm/discussions/issues/354
With new improvement code https://github.com/StackStorm/st2/pull/4743, if pack version is not provided, the latest version for pack from index.json is installed.

Modify existing `e2e` test `tests.test_run_pack_tests_tool` to check:
    1. Install pack without version and check if the latest version for pack from index.json is installed.
       `st2 pack install csv`
    2) install pack with version and check if the version specified is the version installed.
       `st2 pack install xml=0.3.0