### PR TITLE
Fix failure introduced in #176

### DIFF
--- a/packs/tests/actions/chains/test_run_pack_tests_tool.yaml
+++ b/packs/tests/actions/chains/test_run_pack_tests_tool.yaml
@@ -3,7 +3,8 @@ vars:
     base_repo_url: "https://github.com/StackStorm"
     # Note: Pack 1 should have no external dependencies beyond Python stdlib ones.
     pack_to_install_1: "csv"
-    pack_to_install_2: "xml=0.3.0"
+    pack_to_install_2: "xml"
+    pack_to_install_2_with_version: "xml=0.3.0"
     test_timeout: 180
 
 chain:
@@ -38,7 +39,7 @@ chain:
               ST2_AUTH_URL: "{{protocol}}://{{hostname}}:9100"
               ST2_API_URL: "{{protocol}}://{{hostname}}:9101"
               ST2_AUTH_TOKEN: "{{token}}"
-            cmd: "st2 pack install {{ pack_to_install_2 }}"
+            cmd: "st2 pack install {{ pack_to_install_2_with_version }}"
             timeout: "{{test_timeout}}"
         on-success: test_installed_pack_2_version
         on-failure: error_handler
@@ -47,7 +48,7 @@ chain:
         name: test_installed_pack_2_version
         ref: tests.test_installed_pack_version
         params:
-            installed_pack: "{{ pack_to_install_2 }}"
+            installed_pack: "{{ pack_to_install_2_with_version }}"
         on-success: run_pack_tests_without_creating_virtualenv
         on-failure: error_handler
 


### PR DESCRIPTION
This should fix failure (inadvertently) introduced in #176.

After that change, tests started failing with:

```bash
root@pkg-e2e-test-ubuntu18-pr-st2-10491:/home/stanley# st2 execution get 5d3f461ca17deb590fa6fec8
id: 5d3f461ca17deb590fa6fec8
status: failed (1s elapsed)
parameters: 
  cmd: st2-run-pack-tests -p /opt/stackstorm/packs/xml=0.3.0
  env:
    ST2_API_URL: http://127.0.0.1:9101
    ST2_AUTH_TOKEN: 7d4e6fc9c674436bbd0088eee8dc8df0
    ST2_AUTH_URL: http://127.0.0.1:9100
    ST2_BASE_URL: http://127.0.0.1
  timeout: 180
result: 
  failed: true
  return_code: 3
  stderr: ''
  stdout: 'Invalid pack path: /opt/stackstorm/packs/xml=0.3.0'
```

The problem is that invalid argument is passed to ``st2-run-pack-tests`` tool. This tool expects just a pack name without a version.

See https://github.com/StackStorm/st2tests/pull/176#issuecomment-516126833 for more context.