### PR TITLE
Add tests for packs dependencies

### DIFF
--- a/cli/test_pack_install_dependencies.bats
+++ b/cli/test_pack_install_dependencies.bats
@@ -1,0 +1,153 @@
+load '../test_helpers/bats-support/load'
+load '../test_helpers/bats-assert/load'
+
+@test "Fail to install ms pack due to outdated excel pack" {
+	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
+
+	run eval "st2 pack list | grep -q microsoft"
+	assert_failure
+
+	run eval "st2 pack list | grep -q mssql"
+	assert_failure
+
+	run eval "st2 pack list | grep -q excel"
+	assert_failure
+
+	run eval "st2 pack list | grep -q powerpoint"
+	assert_failure
+
+	run st2 pack install excel=0.2.0
+	[[ "$?" -eq 0 ]]
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.0"
+
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms.git
+	assert_failure
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.0"
+}
+
+@test "Fail to install ms pack due to more recent powerpoint pack" {
+	run st2 pack remove microsoft_test mssql microsoft_parent_test microsoft_broken_test
+	assert_success
+
+	run st2 pack install excel
+	[[ "$?" -eq 0 ]]
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	refute_output "0.2.0"
+
+	run st2 pack install powerpoint=0.2.2
+	assert_success
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.2"
+
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms.git
+	assert_failure
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	refute_output "0.2.0"
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.2"
+}
+
+@test "Successfully install the ms pack (excel and powerpoint packs)" {
+	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
+	assert_success
+
+	run eval "st2 pack list | grep -q microsoft"
+	assert_failure
+
+	run eval "st2 pack list | grep -q mssql"
+	assert_failure
+
+	run eval "st2 pack list | grep -q excel"
+	assert_failure
+
+	run eval "st2 pack list | grep -q powerpoint"
+	assert_failure
+
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms.git
+	assert_success
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.4"
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.0"
+}
+
+@test "Successfully install the parent ms pack" {
+	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
+	assert_success
+
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms-parent.git
+	assert_success
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.4"
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.0"
+
+	run eval "st2 pack get mssql --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.1"
+}
+
+@test "Fail to install the broken ms pack" {
+	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
+	assert_success
+
+	run eval "st2 pack list | grep -q microsoft"
+	assert_failure
+
+	run eval "st2 pack list | grep -q mssql"
+	assert_failure
+
+	run eval "st2 pack list | grep -q excel"
+	assert_failure
+
+	run eval "st2 pack list | grep -q powerpoint"
+	assert_failure
+
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms-broken.git
+	assert_failure
+
+	run eval "st2 pack list | grep -q microsoft"
+	assert_failure
+
+	run eval "st2 pack list | grep -q mssql"
+	assert_failure
+
+	run eval "st2 pack list | grep -q excel"
+	assert_failure
+
+	run eval "st2 pack list | grep -q powerpoint"
+	assert_failure
+}

--- a/cli/test_pack_install_dependencies.bats
+++ b/cli/test_pack_install_dependencies.bats
@@ -97,6 +97,21 @@ load '../test_helpers/bats-assert/load'
 	assert_output "0.2.0"
 }
 
+@test "Successfully install the ms pack a second time" {
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms.git
+	assert_success
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.4"
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.0"
+}
+
 @test "Successfully install the parent ms pack" {
 	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
 	assert_success

--- a/cli/test_pack_install_dependencies.bats
+++ b/cli/test_pack_install_dependencies.bats
@@ -67,6 +67,37 @@ load '../test_helpers/bats-assert/load'
 	assert_output "0.2.2"
 }
 
+@test "Successfully install the ms pack by skipping dependencies" {
+	run st2 pack install excel=0.2.4
+	assert_success
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.4"
+
+	run st2 pack install powerpoint=0.2.2
+	assert_success
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.2"
+
+	run st2 pack install --skip-dependencies https://github.com/StackStorm/stackstorm-ms.git
+	assert_success
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.4"
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.2"
+}
+
 @test "Successfully install the ms pack (excel and powerpoint packs)" {
 	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
 	assert_success


### PR DESCRIPTION
End-to-end tests for https://github.com/StackStorm/st2/pull/4769:

* [x] Successfully install pack with dependencies
* [x] PackX with version 2.0 is already installed. User is trying to install PackY which requires PackX with version 1.x only.
* [x] PackX with version 1.0 is already installed. User is trying to install PackY which requires PackX with version 2.0 or above.
* [x] User wants to install PackY which requires PackA and PackB. PackA requires PackX 2.0 and PackB requires PackX 1.x.
* [x] Successfully linearize dependency list and install all dependencies of dependencies