### PR TITLE
Revert "Temporarily remove test to break CI test failure deadlock"

### DIFF
--- a/cli/test_pack_install_dependencies.bats
+++ b/cli/test_pack_install_dependencies.bats
@@ -143,14 +143,28 @@ load '../test_helpers/bats-assert/load'
 	assert_output "0.2.0"
 }
 
-# Removed test to break a CI test failure deadlock
-# 1. ST2 CI fails because mssql pack depends on latest pymssql, which raises
-#    exception on installation: https://github.com/pymssql/pymssql/issues/668
-# 2. The stackstorm-mssql pack CI tests fail because some dependencies in ST2
-#    are out of date
-# 3. Because pack CI tests won't even run, the ST2 Exchange index doesn't get
-#    rebuilt, so version of stackstorm-mssql in ST2 Exchange is stuck with
-#    dependency
+@test "Successfully install the parent ms pack" {
+	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test
+	assert_success
+
+	run st2 pack install https://github.com/StackStorm/stackstorm-ms-parent.git
+	assert_success
+
+	run eval "st2 pack get excel --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.4"
+
+	run eval "st2 pack get powerpoint --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.0"
+
+	run eval "st2 pack get mssql --json | jq -r .version"
+	assert_success
+
+	assert_output "0.2.1"
+}
 
 @test "Fail to install the broken ms pack" {
 	run st2 pack remove excel powerpoint microsoft_test mssql microsoft_parent_test microsoft_broken_test


### PR DESCRIPTION
This reverts commit b7f635da24486b5080740d61398fdfe4a31af8e2.

This PR reverts #181 and adds the removed test back in.