### PR TITLE
Handle implicit relative import for Python 3

### DIFF
--- a/packs/fixtures/actions/scripts/streamwriter-script.py
+++ b/packs/fixtures/actions/scripts/streamwriter-script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/stackstorm/virtualenvs/fixtures/bin/python
 
 import argparse
 import sys


### PR DESCRIPTION
Companion PR for StackStorm/st2ci#163.

This PR handles implicit relative imports for Python 3.

Since this script is called by the `local-shell-script` and `remote-shell-script` runners, it does not have `lib` in `PYTHONPATH`.

Therefore, when running under Python 3, we need to ensure that the relative import path is explicitly specified.

Note that under Python 3, the exact exception is a `ModuleNotFoundError`, but that is a subclass of `ImportError`.

This should hopefully ensure that the script is compatible with both Python 2 and Python 3.

We can revert this once we only support operating systems with Python 3.