### PR TITLE
Don't use the removed --no-site-packages flag to virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(VIRTUALENV_DIR)/bin/activate:
 	@echo
 	@echo "==================== virtualenv ===================="
 	@echo
-	test -d $(VIRTUALENV_DIR) || virtualenv --no-site-packages $(VIRTUALENV_DIR)
+	test -d $(VIRTUALENV_DIR) || virtualenv $(VIRTUALENV_DIR)
 
 	# Setup PYTHONPATH in bash activate script...
 	echo '' >> $(VIRTUALENV_DIR)/bin/activate


### PR DESCRIPTION
It has been deprecated for years, but has been removed in the most recent versions of virtualenv.

This fixes CI for PR #185, which will need to be rebased on top of this.