### PR TITLE
4860 - Fixing st2-self-check script

### DIFF
--- a/packs/tests/actions/chains/test_run_pack_tests_tool.yaml
+++ b/packs/tests/actions/chains/test_run_pack_tests_tool.yaml
@@ -19,12 +19,12 @@ chain:
               ST2_AUTH_TOKEN: "{{token}}"
             cmd: "st2 pack install {{ pack_to_install_1 }}"
             timeout: "{{test_timeout}}"
-        on-success: test_installed_pack_1_version
+        on-success: check_installed_pack_1_version
         on-failure: error_handler
 
     -
-        name: test_installed_pack_1_version
-        ref: tests.test_installed_pack_version
+        name: check_installed_pack_1_version
+        ref: tests.check_installed_pack_version
         params:
             installed_pack: "{{ pack_to_install_1 }}"
         on-success: install_pack_2
@@ -41,12 +41,12 @@ chain:
               ST2_AUTH_TOKEN: "{{token}}"
             cmd: "st2 pack install {{ pack_to_install_2_with_version }}"
             timeout: "{{test_timeout}}"
-        on-success: test_installed_pack_2_version
+        on-success: check_installed_pack_2_version
         on-failure: error_handler
 
     -
-        name: test_installed_pack_2_version
-        ref: tests.test_installed_pack_version
+        name: check_installed_pack_2_version
+        ref: tests.check_installed_pack_version
         params:
             installed_pack: "{{ pack_to_install_2_with_version }}"
         on-success: run_pack_tests_without_creating_virtualenv

--- a/packs/tests/actions/check_installed_pack_version.py
+++ b/packs/tests/actions/check_installed_pack_version.py
@@ -18,7 +18,7 @@ from st2common.util.pack import get_pack_metadata
 from st2common.util.pack_management import get_repo_url
 
 
-class TesetInstalledPackVersionAction(Action):
+class CheckInstalledPackVersionAction(Action):
     def run(self, installed_pack, **kwargs):
         """
         :param installed_pack: Installed pack name with version

--- a/packs/tests/actions/check_installed_pack_version.yaml
+++ b/packs/tests/actions/check_installed_pack_version.yaml
@@ -1,14 +1,14 @@
 ---
-name: "test_installed_pack_version"
+name: "check_installed_pack_version"
 runner_type: "python-script"
-description: "Test installed pack version."
+description: "Compares the 'installed_pack' name and version to the version of the currently installed pack. NOTE: This is specifically NOT named test_xxx because we do not want it run by the st2-self-check script."
 pack: tests
 enabled: true
-entry_point: "test_installed_pack_version.py"
+entry_point: "check_installed_pack_version.py"
 parameters:
   installed_pack:
     type: "string"
-    description: "Name of pack to check"
+    description: "Expected name and version of pack, '=' delimited. Example 'st2=1.2.0'"
     required: true
 # NOTE: Those arguments are unused, temporary workaround for regression
 # introduced in #176


### PR DESCRIPTION
Closes https://github.com/StackStorm/st2/issues/4860

Fixes issue where a dependent action was being treated as a top level test. To fix this i simply renamed `test_installed_pack_version.*` to `check_installed_pack_version.py`. I also updated some of the descriptions in that action so we know why it has a different name.

Steps to verify this on your own StackStorm instance:
```shell
# use my fork of st2tests
sudo sed -i 's/StackStorm\/st2tests/nmaludy\/st2tests/g' /usr/bin/st2-self-check

# use my specific branch of st2tests with this fix
sudo ST2_AUTH_TOKEN=$(st2 auth st2admin -p '<YOUR_PASSWORD_HERE>' -t) /opt/stackstorm/st2/bin/st2-self-check -b bugfix/4860-st2-self-check
```
