### PR TITLE
Use threaded sensor to test monkey_patch on sensor_wrapper

### DIFF
--- a/packs/fixtures/sensors/test_passive_sensor.py
+++ b/packs/fixtures/sensors/test_passive_sensor.py
@@ -39,8 +39,8 @@ class TestPassiveSensor(Sensor):
                 raise Exception('Unhandled endpoint: %s', endpoint)
 
     def run(self):
-        # Stopped
-        self.app.run(host=self.host, port=self.port, threaded=False)
+        # Using a threaded sensor to verify monkey patching
+        self.app.run(host=self.host, port=self.port, threaded=True)
 
     def cleanup(self):
         pass


### PR DESCRIPTION
Sensors that use threaded Flask apps were failing due to monkey_patch call in sensor_wrapper being too late. Update the example sensor to use a threaded Flask app to prevent this happening again, as per sensor_wrapper item in https://github.com/StackStorm/st2tests/issues/188.