### PR TITLE
Fix pyristent to < 0.17 as 0.17 upwards is python 3 only

### DIFF
--- a/packs/fixtures/requirements.txt
+++ b/packs/fixtures/requirements.txt
@@ -1,2 +1,3 @@
 flask
 flask-jsonschema
+pyrsistent<0.17


### PR DESCRIPTION
Fix E2E tests failing on python 2.7 as it tries to pick up latest pyristent which is python 3 support only.
Whilst python 2 is supported by ST2 then use common version of latest 0.16 version of pyristent.