### PR TITLE
 Fix pyristent to < 0.17 as 0.17 upwards is python 3 only (v3.2)

### DIFF
--- a/packs/fixtures/requirements.txt
+++ b/packs/fixtures/requirements.txt
@@ -1,2 +1,3 @@
 flask
 flask-jsonschema
+pyrsistent<0.17


### PR DESCRIPTION
The https://github.com/StackStorm/st2tests/pull/191 was merged to `master` fixing the st2tests failures for the unstable builds.


Cherry-picking changes to the latest versioned branch `v3.2` aka `stable` st2tests branch. This branch is used for the st2cicd stable builds and should fix the CI/CD failures for `production stable`:

```
st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirements from file /opt/stackstorm/packs/fixtures/requirements.txt with command /opt/stackstorm/virtualenvs/fixtures/bin/pip install -U -r /opt/stackstorm/packs/fixtures/requirements.txt.
Traceback (most recent call last):
  File \"/opt/stackstorm/st2/lib/python2.7/site-packages/python_runner/python_action_wrapper.py\", line 333, in <module>
    obj.run()
  File \"/opt/stackstorm/st2/lib/python2.7/site-packages/python_runner/python_action_wrapper.py\", line 192, in run
    output = action.run(**self._parameters)
  File \"/opt/stackstorm/packs/packs/actions/pack_mgmt/setup_virtualenv.py\", line 88, in run
    no_download=no_download)
  File \"/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/util/virtualenvs.py\", line 122, in setup_pack_virtualenv
    logger=logger)
  File \"/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/util/virtualenvs.py\", line 272, in install_requirements
    (requirements_file_path, stdout, stderr))
Exception: Failed to install requirements from \"/opt/stackstorm/packs/fixtures/requirements.txt\": Collecting flask (from -r /opt/stackstorm/packs/fixtures/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/f2/28/2a03252dfb9ebf377f40fba6a7841b47083260bf8bd8e737b0c6952df83f/Flask-1.1.2-py2.py3-none-any.whl
Collecting flask-jsonschema (from -r /opt/stackstorm/packs/fixtures/requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/59/3d/1b3a57332cc80c2abc8accf8df7b07ba986109f9d477d7e846976e466edb/Flask-JsonSchema-0.1.1.tar.gz
Collecting Jinja2>=2.10.1 (from flask->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/30/9e/f663a2aa66a09d838042ae1a2c5659828bb9b41ea3a6efa20a20fd92b121/Jinja2-2.11.2-py2.py3-none-any.whl
Collecting itsdangerous>=0.24 (from flask->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/76/ae/44b03b253d6fade317f32c24d100b3b35c2239807046a4c953c7b89fa49e/itsdangerous-1.1.0-py2.py3-none-any.whl
Collecting click>=5.1 (from flask->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl
Collecting Werkzeug>=0.15 (from flask->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/cc/94/5f7079a0e00bd6863ef8f1da638721e9da21e5bacee597595b318f71d62e/Werkzeug-1.0.1-py2.py3-none-any.whl
Collecting jsonschema>=2.1.0 (from flask-jsonschema->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/c5/8f/51e89ce52a085483359217bc72cdbf6e75ee595d5b1d4b5ade40c7e018b8/jsonschema-3.2.0-py2.py3-none-any.whl (56kB)
Collecting MarkupSafe>=0.23 (from Jinja2>=2.10.1->flask->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/fb/40/f3adb7cf24a8012813c5edb20329eb22d5d8e2a0ecf73d21d6b85865da11/MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl
Requirement already satisfied, skipping upgrade: setuptools in /opt/stackstorm/virtualenvs/fixtures/lib/python2.7/site-packages (from jsonschema>=2.1.0->flask-jsonschema->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 2)) (41.0.1)
Collecting importlib-metadata; python_version < \"3.8\" (from jsonschema>=2.1.0->flask-jsonschema->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/8e/58/cdea07eb51fc2b906db0968a94700866fc46249bdc75cac23f9d13168929/importlib_metadata-1.7.0-py2.py3-none-any.whl
Collecting functools32; python_version < \"3\" (from jsonschema>=2.1.0->flask-jsonschema->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/c5/60/6ac26ad05857c601308d8fb9e87fa36d0ebf889423f47c3502ef034365db/functools32-3.2.3-2.tar.gz
Collecting pyrsistent>=0.14.0 (from jsonschema>=2.1.0->flask-jsonschema->-r /opt/stackstorm/packs/fixtures/requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/7d/ae/90ddcf28fb8eee5d4990920586d2856342e42faa95f39223f0b9762ef264/pyrsistent-0.17.2.tar.gz (106kB)
 (stderr: DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
ERROR: pyrsistent requires Python '>=3.5' but the running Python is 2.7.5
WARNING: You are using pip version 19.1.1, however version 20.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```
