### PR TITLE
Allow other notification channels besides hubot

### DIFF
--- a/chatops/test_hubot.bats
+++ b/chatops/test_hubot.bats
@@ -33,7 +33,7 @@ load '../test_helpers/bats-assert/load'
 	run eval "echo '$RESULTS' | jq -r '.[].ref'"
 	assert_success
 
-	assert_output "chatops.notify"
+	assert_output --partial "chatops.notify"
 
 	run eval "echo '$RESULTS' | jq -r '.[].enabled'"
 	assert_success


### PR DESCRIPTION
This PR should fix st2tests to work with StackStorm/st2#5051. Once that is merged we can add tests similar to #193, I will push that into a different PR.