### PR TITLE
Allow errbot notify rule

### DIFF
--- a/chatops/test_hubot.bats
+++ b/chatops/test_hubot.bats
@@ -34,10 +34,12 @@ load '../test_helpers/bats-assert/load'
 	assert_success
 
 	assert_output --partial "chatops.notify"
+	assert_output --partial "chatops.notify-errbot"
 
-	run eval "echo '$RESULTS' | jq -r '.[] | select( (.ref == \"chatops.notify\") and .enabled == true) .ref'"
+	run eval "echo '$RESULTS' | jq -r '.[] | select( (.ref == \"chatops.notify\" or .ref == \"chatops.notify-errbot\") and .enabled == true) .ref'"
 	assert_success
 	assert_output --partial "chatops.notify"
+	assert_output --partial "chatops.notify-errbot"
 }
 
 @test "hubot help command works" {


### PR DESCRIPTION
This PR should be merged after #194 and StackStorm/st2#5051 (this branch will need to be rebased).

This PR adds a check for the `chatops.notify-errbot` rule, similar to how #194 checks for `chatops.notify`, but without relying on the ordering of the rule listing (so this test is less brittle).