### PR TITLE
Fix ChatOps tests - allow more than one ChatOps notification channels

### DIFF
--- a/chatops/test_hubot.bats
+++ b/chatops/test_hubot.bats
@@ -35,10 +35,9 @@ load '../test_helpers/bats-assert/load'
 
 	assert_output --partial "chatops.notify"
 
-	run eval "echo '$RESULTS' | jq -r '.[].enabled'"
+	run eval "echo '$RESULTS' | jq -r '.[] | select( (.ref == \"chatops.notify\") and .enabled == true) .ref'"
 	assert_success
-
-	assert_output "true"
+	assert_output --partial "chatops.notify"
 }
 
 @test "hubot help command works" {


### PR DESCRIPTION
Add on to #194 - fix the rest of the issues with adding `chatops.notify-errbot`.

Manually tested on an end-to-end VM.