### PR TITLE
Remove st2debug component, as only contained submit-debug-info

### DIFF
--- a/spec/vagrant/core_spec.rb
+++ b/spec/vagrant/core_spec.rb
@@ -23,7 +23,7 @@ BUILD_REDHAT_PACKAGES.each do |package|
 end
 
 ## StackStorm Package Installation
-ST2_PACKAGES = %w(st2common st2reactor st2actions st2api st2auth st2debug)
+ST2_PACKAGES = %w(st2common st2reactor st2actions st2api st2auth)
 ST2_DEBIAN_PACKAGES = %w(python-st2client)
 ST2_REDHAT_PACKAGES = %w(st2client)
 


### PR DESCRIPTION
Companion to StackStorm/st2#5103.
The only item in st2debug component is the submit-debug-info component, so when this is removed the st2debug component also is removed. So remove it from the components.