### PR TITLE
Fix the st2chatops e2e tests

### DIFF
--- a/packs/chatops_tests/actions/test_aliases_with_slack.py
+++ b/packs/chatops_tests/actions/test_aliases_with_slack.py
@@ -279,7 +279,7 @@ class SlackEndToEndTestCase(unittest2.TestCase):
 
         # Check the pretext
         msg_pretext = messages[0]['attachments'][0]['pretext']
-        self.assertRegex(msg_pretext, r"<@{userid}>: I'm sorry, Dave. I'm afraid I can't do that. ".format(userid=self.userid))
+        self.assertRegex(msg_pretext, r"<@{userid}>: I'm sorry, Dave. I'm afraid I can't do that.".format(userid=self.userid))
 
         # Test attachment
         msg_text = messages[0]['attachments'][0]['text']
@@ -921,7 +921,7 @@ class SlackEndToEndTestCase(unittest2.TestCase):
                          'Details are as follows:\n'
                          'Host: `localhost`\n'
                          '    ---&gt; stdout: ChatOps run command with custom result format\n'
-                         '    ---&gt; stderr: \n')
+                         '    ---&gt; stderr:')
         self.assertEqual(msg_text, expected_text)
 
         # Drain the event buffer
@@ -973,10 +973,10 @@ class SlackEndToEndTestCase(unittest2.TestCase):
         expected_details = 'Details are as follows:\n'
         expected_127_0_0_1 = ('Host: `127.0.0.1`\n'
                               '    ---&gt; stdout: ChatOps run command with custom result format on multiple hosts\n'
-                              '    ---&gt; stderr: \n')
+                              '    ---&gt; stderr:')
         expected_localhost = ('Host: `localhost`\n'
                               '    ---&gt; stdout: ChatOps run command with custom result format on multiple hosts\n'
-                              '    ---&gt; stderr: \n')
+                              '    ---&gt; stderr:')
         self.assertIn(expected_report, msg_text)
         self.assertIn(expected_details, msg_text)
         self.assertIn(expected_127_0_0_1, msg_text)
@@ -1051,7 +1051,7 @@ class SlackEndToEndTestCase(unittest2.TestCase):
         self.assertIsNotNone(messages[1]['attachments'][0].get('text'))
 
         # Check the pretext
-        self.assertEqual(messages[1]['attachments'][0]['pretext'], '<@{userid}>: action completed! '.format(userid=self.userid))
+        self.assertEqual(messages[1]['attachments'][0]['pretext'], '<@{userid}>: action completed!'.format(userid=self.userid))
 
         # Test attachment
         self.assertEqual(messages[1]['attachments'][0]['fallback'],
@@ -1094,14 +1094,14 @@ class SlackEndToEndTestCase(unittest2.TestCase):
         self.assertIsNotNone(messages[1]['attachments'][0].get('text'))
 
         # Check the pretext
-        self.assertEqual(messages[1]['attachments'][0]['pretext'], r'<@{userid}>: your kittens are here! '.format(userid=self.userid))
+        self.assertEqual(messages[1]['attachments'][0]['pretext'], r'<@{userid}>: your kittens are here!'.format(userid=self.userid))
 
         # Test fallback
         self.assertEqual(messages[1]['attachments'][0]['fallback'],
                          messages[1]['attachments'][0]['text'])
 
         # Test attachment
-        self.assertEqual(messages[1]['attachments'][0]['text'], ' Regards from the Box Kingdom.')
+        self.assertEqual(messages[1]['attachments'][0]['text'], 'Regards from the Box Kingdom.')
         self.assertEqual(messages[1]['attachments'][0]['fields'],
                          [
                             {
@@ -1155,7 +1155,7 @@ class SlackEndToEndTestCase(unittest2.TestCase):
         self.assertIsNotNone(messages[1]['attachments'][0].get('text'))
 
         # Check the pretext
-        self.assertEqual(messages[1]['attachments'][0]['pretext'], r'<@{userid}>: '.format(userid=self.userid))
+        self.assertEqual(messages[1]['attachments'][0]['pretext'], r'<@{userid}>:'.format(userid=self.userid))
 
         # Test fallback
         self.assertEqual(messages[1]['attachments'][0]['fallback'],


### PR DESCRIPTION
Fixes formatting for Slack, changed recently in the upstream and failing the st2cicd e2e tests, including the st2 packages promotion workflows.

It turns out the fix is simple with just a few minor changes.

### Before:
```
{
  "10.0.3.44": {
    "failed": true,
    "stderr": "FF.F....F..F...F.......
======================================================================
FAIL: test_alias_with_custom_result_format (__main__.SlackEndToEndTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py\", line 925, in test_alias_with_custom_result_format
    self.assertEqual(msg_text, expected_text)
AssertionError: 'Ran [148 chars] run command with custom result format\
    ---&gt; stderr:' != 'Ran [148 chars] run command with custom result format\
    ---&gt; stderr: \
'
  Ran command `echo ChatOps run command with custom result format` on `1` host.
  
  Details are as follows:
  Host: `localhost`
      ---&gt; stdout: ChatOps run command with custom result format
-     ---&gt; stderr:+     ---&gt; stderr: 
?                    ++


======================================================================
FAIL: test_alias_with_custom_result_format_and_multiple_hosts (__main__.SlackEndToEndTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py\", line 982, in test_alias_with_custom_result_format_and_multiple_hosts
    self.assertIn(expected_127_0_0_1, msg_text)
AssertionError: 'Host: `127.0.0.1`\
    ---&gt; stdout: ChatOps run command with custom result format on multiple hosts\
    ---&gt; stderr: \
' not found in 'Ran command `echo ChatOps run command with custom result format on multiple hosts` on `2` hosts.\
\
Details are as follows:\
Host: `localhost`\
    ---&gt; stdout: ChatOps run command with custom result format on multiple hosts\
    ---&gt; stderr: \
Host: `127.0.0.1`\
    ---&gt; stdout: ChatOps run command with custom result format on multiple hosts\
    ---&gt; stderr:'

======================================================================
FAIL: test_attachment_and_plaintext_backup (__main__.SlackEndToEndTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py\", line 1054, in test_attachment_and_plaintext_backup
    self.assertEqual(messages[1]['attachments'][0]['pretext'], '<@{userid}>: action completed! '.format(userid=self.userid))
AssertionError: '<@UHYEWU26R>: action completed!' != '<@UHYEWU26R>: action completed! '
- <@UHYEWU26R>: action completed!
+ <@UHYEWU26R>: action completed! 
?                                +


======================================================================
FAIL: test_fields_parameter (__main__.SlackEndToEndTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py\", line 1097, in test_fields_parameter
    self.assertEqual(messages[1]['attachments'][0]['pretext'], r'<@{userid}>: your kittens are here! '.format(userid=self.userid))
AssertionError: '<@UHYEWU26R>: your kittens are here!' != '<@UHYEWU26R>: your kittens are here! '
- <@UHYEWU26R>: your kittens are here!
+ <@UHYEWU26R>: your kittens are here! 
?                                     +


======================================================================
FAIL: test_jinja_input_parameters (__main__.SlackEndToEndTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py\", line 1158, in test_jinja_input_parameters
    self.assertEqual(messages[1]['attachments'][0]['pretext'], r'<@{userid}>: '.format(userid=self.userid))
AssertionError: '<@UHYEWU26R>:' != '<@UHYEWU26R>: '
- <@UHYEWU26R>:
+ <@UHYEWU26R>: 
?              +


======================================================================
FAIL: test_run_command_on_localhost_with_bad_argument (__main__.SlackEndToEndTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File \"/opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py\", line 282, in test_run_command_on_localhost_with_bad_argument
    self.assertRegex(msg_pretext, r\"<@{userid}>: I'm sorry, Dave. I'm afraid I can't do that. \".format(userid=self.userid))
AssertionError: Regex didn't match: \"<@UHYEWU26R>: I'm sorry, Dave. I'm afraid I can't do that. \" not found in \"<@UHYEWU26R>: I'm sorry, Dave. I'm afraid I can't do that.\"

----------------------------------------------------------------------
Ran 23 tests in 576.997s

FAILED (failures=6)",
    "return_code": 1,
    "succeeded": false,
    "stdout": ""
  }
}
```

### After:
```
python /opt/stackstorm/packs/chatops_tests/actions/test_aliases_with_slack.py
.......................
----------------------------------------------------------------------
Ran 23 tests in 154.843s

OK

```
